### PR TITLE
Add shuffle to `HillClimbing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["algorithms", "data-structures", "mathematics", "science"]
 [dependencies]
 approx = "^0.5"
 bimap = { version = "^0.6", features = [ "serde" ] }
+indexmap = { version = "^1.9", features = [ "rayon" ] }
 is_sorted = "^0.1"
 itertools = "^0.10"
 libm = "^0.2"
@@ -26,6 +27,8 @@ page_size = "^0.5"
 pest = "^2.5"
 pest_derive = "^2.5"
 polars = { version = "^0.27", features = [ "dtype-categorical", "ndarray" ] }
+rand = "^0.8"
+rand_xoshiro = "^0.6"
 rayon = "^1.6"
 rustc-hash = "^1.1"
 serde = { version = "^1.0", features = [ "derive" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,13 @@ tempfile = "^3.3"
 thiserror = "^1.0"
 
 [dev-dependencies]
+env_logger = "^0.10"
 ndarray = { version = "^0.15", features = [ "approx-0_5", "rayon", "serde" ] }
 ndarray-linalg = { version = "^0.16", features = [ "openblas-system" ] }
 regex = "^1.7"
 serde = "^1.0"
 serde_json = "^1.0"
+test-log = "^0.2"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "./katex.html"]

--- a/src/discovery/hill_climbing.rs
+++ b/src/discovery/hill_climbing.rs
@@ -1,9 +1,12 @@
-use std::{collections::BTreeSet, marker::PhantomData};
+use std::{hash::BuildHasherDefault, marker::PhantomData};
 
+use indexmap::IndexSet;
 use itertools::iproduct;
 use log::debug;
+use rand::prelude::*;
+use rand_xoshiro::Xoshiro256PlusPlus;
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHasher};
 
 use super::{score_types, DecomposableScoringCriterion, PriorKnowledge, ScoringCriterion};
 use crate::{
@@ -21,7 +24,7 @@ type CU<K> = Vec<(K, f64)>;
 type KE = (usize, Vec<usize>);
 
 /// Local edge space type
-type E = BTreeSet<(usize, usize)>;
+type E = IndexSet<(usize, usize), BuildHasherDefault<FxHasher>>;
 /// Local operations edge space type.
 type ES = (
     E, // To-be-added space,
@@ -53,6 +56,7 @@ where
     S: ScoringCriterion<D, G, ScoreType = ST>,
 {
     max_iter: usize,
+    seed: Option<u64>,
     _d: PhantomData<D>,
     _k: PhantomData<K>,
     g: Option<G>,
@@ -70,6 +74,7 @@ where
     pub const fn new(s: S) -> Self {
         Self {
             max_iter: usize::MAX,
+            seed: None,
             _d: PhantomData,
             _k: PhantomData,
             g: None,
@@ -88,9 +93,18 @@ where
 
     /// Set max iterations.
     #[inline]
-    pub fn with_max_iter(mut self, max_iter: usize) -> Self {
+    pub const fn with_max_iter(mut self, max_iter: usize) -> Self {
         // Set hyper parameter.
         self.max_iter = max_iter;
+
+        self
+    }
+
+    /// Enable edge operations shuffling and set the seed.
+    #[inline]
+    pub const fn with_shuffle(mut self, seed: u64) -> Self {
+        // Set random number generator seed.
+        self.seed = Some(seed);
 
         self
     }
@@ -227,26 +241,48 @@ where
         // Get number of variables.
         let n = d.labels().len();
         // Get current edge set.
-        let e: BTreeSet<_> = E!(g).collect();
-
+        let e: E = E!(g).collect();
         // Initialize potential edges to be added.
-        let add: BTreeSet<_> = iproduct!(0..n, 0..n)
+        let mut add: E = iproduct!(0..n, 0..n)
             // Remove any edge (X, Y) s.t. X == Y, is present in the initial graph, or is in the forbidden list.
             .filter(|&(x, y)| x != y && !e.contains(&(x, y)) && !k.has_forbidden(x, y))
             .collect();
-
         // Initialize potential edges to be deleted.
-        let del: BTreeSet<_> = e
+        let mut del: E = e
             .clone()
             .into_iter()
             .filter(|(x, y)| !k.has_required(*x, *y))
             .collect(); // Remove any edge in the required list.
-
-        // Initialize potential edges to be reversed.
-        let rev: BTreeSet<_> = e
+                        // Initialize potential edges to be reversed.
+        let mut rev: E = e
             .into_iter()
             .filter(|(x, y)| !k.has_required(*x, *y) && !k.has_forbidden(*y, *x))
             .collect(); // Remove any reversed edge in the forbidden list.
+
+        // Check if random number generator has been set.
+        if let Some(seed) = self.seed {
+            // Initialize random number generator.
+            let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
+            // Shuffle sets.
+            (add, del, rev) = {
+                // Convert to vectors.
+                let (mut add, mut del, mut rev): (Vec<_>, Vec<_>, Vec<_>) = (
+                    add.into_iter().collect(),
+                    del.into_iter().collect(),
+                    rev.into_iter().collect(),
+                );
+                // Shuffle vectors in-place.
+                add.shuffle(&mut rng);
+                del.shuffle(&mut rng);
+                rev.shuffle(&mut rng);
+                // Convert to sets.
+                (
+                    add.into_iter().collect(),
+                    del.into_iter().collect(),
+                    rev.into_iter().collect(),
+                )
+            }
+        }
 
         (g, (add, del, rev))
     }

--- a/src/discovery/hill_climbing.rs
+++ b/src/discovery/hill_climbing.rs
@@ -240,49 +240,34 @@ where
 
         // Get number of variables.
         let n = d.labels().len();
+        // Get columns index.
+        let mut n: Vec<_> = (0..n).collect();
+        // Check if random number generator has been set.
+        if let Some(seed) = self.seed {
+            // Initialize random number generator.
+            let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
+            // Shuffle columns.
+            n.shuffle(&mut rng);
+        }
+
         // Get current edge set.
         let e: E = E!(g).collect();
         // Initialize potential edges to be added.
-        let mut add: E = iproduct!(0..n, 0..n)
+        let add: E = iproduct!(n.clone(), n)
             // Remove any edge (X, Y) s.t. X == Y, is present in the initial graph, or is in the forbidden list.
             .filter(|&(x, y)| x != y && !e.contains(&(x, y)) && !k.has_forbidden(x, y))
             .collect();
         // Initialize potential edges to be deleted.
-        let mut del: E = e
+        let del: E = e
             .clone()
             .into_iter()
             .filter(|(x, y)| !k.has_required(*x, *y))
             .collect(); // Remove any edge in the required list.
                         // Initialize potential edges to be reversed.
-        let mut rev: E = e
+        let rev: E = e
             .into_iter()
             .filter(|(x, y)| !k.has_required(*x, *y) && !k.has_forbidden(*y, *x))
             .collect(); // Remove any reversed edge in the forbidden list.
-
-        // Check if random number generator has been set.
-        if let Some(seed) = self.seed {
-            // Initialize random number generator.
-            let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
-            // Shuffle sets.
-            (add, del, rev) = {
-                // Convert to vectors.
-                let (mut add, mut del, mut rev): (Vec<_>, Vec<_>, Vec<_>) = (
-                    add.into_iter().collect(),
-                    del.into_iter().collect(),
-                    rev.into_iter().collect(),
-                );
-                // Shuffle vectors in-place.
-                add.shuffle(&mut rng);
-                del.shuffle(&mut rng);
-                rev.shuffle(&mut rng);
-                // Convert to sets.
-                (
-                    add.into_iter().collect(),
-                    del.into_iter().collect(),
-                    rev.into_iter().collect(),
-                )
-            }
-        }
 
         (g, (add, del, rev))
     }

--- a/src/discovery/hill_climbing.rs
+++ b/src/discovery/hill_climbing.rs
@@ -1,7 +1,7 @@
 use std::{hash::BuildHasherDefault, marker::PhantomData};
 
 use indexmap::IndexSet;
-use itertools::iproduct;
+use itertools::{iproduct, Itertools};
 use log::{debug, trace};
 use rand::prelude::*;
 use rand_xoshiro::Xoshiro256PlusPlus;
@@ -248,6 +248,11 @@ where
             let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
             // Shuffle columns.
             n.shuffle(&mut rng);
+            // Log shuffled columns.
+            debug!(
+                "Seed is set, shuffled columns as: [{}]",
+                n.iter().map(|&x| g.label(x)).format(", ")
+            );
         }
 
         // Get current edge set.

--- a/src/discovery/hill_climbing.rs
+++ b/src/discovery/hill_climbing.rs
@@ -100,7 +100,7 @@ where
         self
     }
 
-    /// Enable edge operations shuffling and set the seed.
+    /// Enables columns shuffling by setting the seed.
     #[inline]
     pub const fn with_shuffle(mut self, seed: u64) -> Self {
         // Set random number generator seed.

--- a/src/discovery/hill_climbing.rs
+++ b/src/discovery/hill_climbing.rs
@@ -2,7 +2,7 @@ use std::{hash::BuildHasherDefault, marker::PhantomData};
 
 use indexmap::IndexSet;
 use itertools::iproduct;
-use log::debug;
+use log::{debug, trace};
 use rand::prelude::*;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use rayon::prelude::*;
@@ -292,7 +292,7 @@ where
         // Check if invalid.
         if !is_valid {
             // Log invalid.
-            debug!(
+            trace!(
                 "op: {}({}, {}), invalid",
                 match OP {
                     Op::ADD => "Add",
@@ -391,7 +391,7 @@ where
         };
 
         // Log current operation delta.
-        debug!(
+        trace!(
             "op: {}({}, {}), delta: {}",
             match OP {
                 Op::ADD => "Add",

--- a/src/stats/akaike_information_criterion/categorical.rs
+++ b/src/stats/akaike_information_criterion/categorical.rs
@@ -6,12 +6,14 @@ use crate::{
     stats::LogLikelihood,
 };
 
-impl<const RESCALED: bool, const PARALLEL: bool>
-    AkaikeInformationCriterion<CategoricalDataMatrix, RESCALED, PARALLEL>
+impl<G, const RESCALED: bool, const PARALLEL: bool>
+    DecomposableScoringCriterion<CategoricalDataMatrix, G>
+    for AkaikeInformationCriterion<CategoricalDataMatrix, RESCALED, PARALLEL>
+where
+    G: DirectedGraph<Direction = directions::Directed>,
 {
-    /// Computes AIC given data set $\mathbf{D}$ and vertex $X$ and parents $\mathbf{Z}$.
     #[inline]
-    pub fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
+    fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
         // Get the cardinality.
         let cards = d.cardinality();
         // Get the cardinality of vertices.
@@ -21,28 +23,16 @@ impl<const RESCALED: bool, const PARALLEL: bool>
         let theta = ((card_x - 1) * card_z) as f64;
 
         // Initialize the log-likelihood functor.
-        let ll = LogLikelihood::<CategoricalDataMatrix, PARALLEL>::new();
+        let s = LogLikelihood::<_, PARALLEL>::new();
         // Compute the log-likelihood.
-        let ll = ll.call(d, x, z);
+        let s = DecomposableScoringCriterion::<CategoricalDataMatrix, G>::call(&s, d, x, z);
 
         // Check if AIC must be scaled.
         match RESCALED {
             // Rescale AIC by -2, coherently with LL.
-            true => ll - self.k * theta,
+            true => s - self.k * theta,
             // Otherwise, compute original AIC.
-            false => 2. * self.k * theta - 2. * ll,
+            false => 2. * self.k * theta - 2. * s,
         }
-    }
-}
-
-impl<G, const RESCALED: bool, const PARALLEL: bool>
-    DecomposableScoringCriterion<CategoricalDataMatrix, G>
-    for AkaikeInformationCriterion<CategoricalDataMatrix, RESCALED, PARALLEL>
-where
-    G: DirectedGraph<Direction = directions::Directed>,
-{
-    #[inline]
-    fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
-        self.call(d, x, z)
     }
 }

--- a/src/stats/akaike_information_criterion/gaussian.rs
+++ b/src/stats/akaike_information_criterion/gaussian.rs
@@ -6,31 +6,6 @@ use crate::{
     stats::LogLikelihood,
 };
 
-impl<const RESCALED: bool, const PARALLEL: bool>
-    AkaikeInformationCriterion<ContinuousDataMatrix, RESCALED, PARALLEL>
-{
-    /// Computes AIC given data set $\mathbf{D}$ and vertex $X$ and parents $\mathbf{Z}$.
-    #[inline]
-    pub fn call(&self, d: &ContinuousDataMatrix, x: usize, z: &[usize]) -> f64 {
-        // Compute the number of parameters.
-        // NOTE: Intercept, standard deviation and regression coefficient per parent.
-        let theta = (2 + z.len()) as f64;
-
-        // Initialize the log-likelihood functor.
-        let ll = LogLikelihood::<ContinuousDataMatrix, PARALLEL>::new();
-        // Compute the log-likelihood.
-        let ll = ll.call(d, x, z);
-
-        // Check if AIC must be scaled.
-        match RESCALED {
-            // Rescale AIC by -2, coherently with LL.
-            true => ll - self.k * theta,
-            // Otherwise, compute original AIC.
-            false => 2. * self.k * theta - 2. * ll,
-        }
-    }
-}
-
 impl<G, const RESCALED: bool, const PARALLEL: bool>
     DecomposableScoringCriterion<ContinuousDataMatrix, G>
     for AkaikeInformationCriterion<ContinuousDataMatrix, RESCALED, PARALLEL>
@@ -39,6 +14,21 @@ where
 {
     #[inline]
     fn call(&self, d: &ContinuousDataMatrix, x: usize, z: &[usize]) -> f64 {
-        self.call(d, x, z)
+        // Compute the number of parameters.
+        // NOTE: Intercept, standard deviation and regression coefficient per parent.
+        let theta = (2 + z.len()) as f64;
+
+        // Initialize the log-likelihood functor.
+        let s = LogLikelihood::<_, PARALLEL>::new();
+        // Compute the log-likelihood.
+        let s = DecomposableScoringCriterion::<ContinuousDataMatrix, G>::call(&s, d, x, z);
+
+        // Check if AIC must be scaled.
+        match RESCALED {
+            // Rescale AIC by -2, coherently with LL.
+            true => s - self.k * theta,
+            // Otherwise, compute original AIC.
+            false => 2. * self.k * theta - 2. * s,
+        }
     }
 }

--- a/src/stats/bayesian_information_criterion/categorical.rs
+++ b/src/stats/bayesian_information_criterion/categorical.rs
@@ -6,12 +6,14 @@ use crate::{
     stats::LogLikelihood,
 };
 
-impl<const RESCALED: bool, const PARALLEL: bool>
-    BayesianInformationCriterion<CategoricalDataMatrix, RESCALED, PARALLEL>
+impl<G, const RESCALED: bool, const PARALLEL: bool>
+    DecomposableScoringCriterion<CategoricalDataMatrix, G>
+    for BayesianInformationCriterion<CategoricalDataMatrix, RESCALED, PARALLEL>
+where
+    G: DirectedGraph<Direction = directions::Directed>,
 {
-    /// Computes BIC given data set $\mathbf{D}$ and vertex $X$ and parents $\mathbf{Z}$.
     #[inline]
-    pub fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
+    fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
         // Get the sample size.
         let n = d.nrows() as f64;
 
@@ -24,28 +26,16 @@ impl<const RESCALED: bool, const PARALLEL: bool>
         let theta = ((card_x - 1) * card_z) as f64;
 
         // Initialize the log-likelihood functor.
-        let ll = LogLikelihood::<CategoricalDataMatrix, PARALLEL>::new();
+        let s = LogLikelihood::<_, PARALLEL>::new();
         // Compute the log-likelihood.
-        let ll = ll.call(d, x, z);
+        let s = DecomposableScoringCriterion::<CategoricalDataMatrix, G>::call(&s, d, x, z);
 
         // Check if BIC must be scaled.
         match RESCALED {
             // Rescale BIC by -2, coherently with LL.
-            true => ll - 0.5 * self.k * theta * f64::ln(n),
+            true => s - 0.5 * self.k * theta * f64::ln(n),
             // Otherwise, compute original BIC.
-            false => self.k * theta * f64::ln(n) - 2. * ll,
+            false => self.k * theta * f64::ln(n) - 2. * s,
         }
-    }
-}
-
-impl<G, const RESCALED: bool, const PARALLEL: bool>
-    DecomposableScoringCriterion<CategoricalDataMatrix, G>
-    for BayesianInformationCriterion<CategoricalDataMatrix, RESCALED, PARALLEL>
-where
-    G: DirectedGraph<Direction = directions::Directed>,
-{
-    #[inline]
-    fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
-        self.call(d, x, z)
     }
 }

--- a/src/stats/bayesian_information_criterion/gaussian.rs
+++ b/src/stats/bayesian_information_criterion/gaussian.rs
@@ -6,34 +6,6 @@ use crate::{
     stats::LogLikelihood,
 };
 
-impl<const RESCALED: bool, const PARALLEL: bool>
-    BayesianInformationCriterion<ContinuousDataMatrix, RESCALED, PARALLEL>
-{
-    /// Computes BIC given data set $\mathbf{D}$ and vertex $X$ and parents $\mathbf{Z}$.
-    #[inline]
-    pub fn call(&self, d: &ContinuousDataMatrix, x: usize, z: &[usize]) -> f64 {
-        // Get the sample size.
-        let n = d.nrows() as f64;
-
-        // Compute the number of parameters.
-        // NOTE: Intercept, standard deviation and regression coefficient per parent.
-        let theta = (2 + z.len()) as f64;
-
-        // Initialize the log-likelihood functor.
-        let ll = LogLikelihood::<ContinuousDataMatrix, PARALLEL>::new();
-        // Compute the log-likelihood.
-        let ll = ll.call(d, x, z);
-
-        // Check if BIC must be scaled.
-        match RESCALED {
-            // Rescale BIC by -2, coherently with LL.
-            true => ll - 0.5 * self.k * theta * f64::ln(n),
-            // Otherwise, compute original BIC.
-            false => self.k * theta * f64::ln(n) - 2. * ll,
-        }
-    }
-}
-
 impl<G, const RESCALED: bool, const PARALLEL: bool>
     DecomposableScoringCriterion<ContinuousDataMatrix, G>
     for BayesianInformationCriterion<ContinuousDataMatrix, RESCALED, PARALLEL>
@@ -42,6 +14,24 @@ where
 {
     #[inline]
     fn call(&self, d: &ContinuousDataMatrix, x: usize, z: &[usize]) -> f64 {
-        self.call(d, x, z)
+        // Get the sample size.
+        let n = d.nrows() as f64;
+
+        // Compute the number of parameters.
+        // NOTE: Intercept, standard deviation and regression coefficient per parent.
+        let theta = (2 + z.len()) as f64;
+
+        // Initialize the log-likelihood functor.
+        let s = LogLikelihood::<_, PARALLEL>::new();
+        // Compute the log-likelihood.
+        let s = DecomposableScoringCriterion::<ContinuousDataMatrix, G>::call(&s, d, x, z);
+
+        // Check if BIC must be scaled.
+        match RESCALED {
+            // Rescale BIC by -2, coherently with LL.
+            true => s - 0.5 * self.k * theta * f64::ln(n),
+            // Otherwise, compute original BIC.
+            false => self.k * theta * f64::ln(n) - 2. * s,
+        }
     }
 }

--- a/src/stats/log_likelihood/categorical.rs
+++ b/src/stats/log_likelihood/categorical.rs
@@ -72,17 +72,6 @@ impl<const PARALLEL: bool> ConditionalLogLikelihood<CategoricalDataMatrix, PARAL
     }
 }
 
-impl<const PARALLEL: bool> LogLikelihood<CategoricalDataMatrix, PARALLEL> {
-    /// Computes LL given data set $\mathbf{D}$ and vertex $X$ and parents $\mathbf{Z}$.
-    #[inline]
-    pub fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
-        match z.is_empty() {
-            true => MarginalLogLikelihood::<CategoricalDataMatrix, PARALLEL>::call(d, x),
-            false => ConditionalLogLikelihood::<CategoricalDataMatrix, PARALLEL>::call(d, x, z),
-        }
-    }
-}
-
 impl<G, const PARALLEL: bool> DecomposableScoringCriterion<CategoricalDataMatrix, G>
     for LogLikelihood<CategoricalDataMatrix, PARALLEL>
 where
@@ -90,6 +79,9 @@ where
 {
     #[inline]
     fn call(&self, d: &CategoricalDataMatrix, x: usize, z: &[usize]) -> f64 {
-        self.call(d, x, z)
+        match z.is_empty() {
+            true => MarginalLogLikelihood::<CategoricalDataMatrix, PARALLEL>::call(d, x),
+            false => ConditionalLogLikelihood::<CategoricalDataMatrix, PARALLEL>::call(d, x, z),
+        }
     }
 }

--- a/src/stats/log_likelihood/gaussian.rs
+++ b/src/stats/log_likelihood/gaussian.rs
@@ -99,17 +99,6 @@ impl<const PARALLEL: bool> ConditionalLogLikelihood<ContinuousDataMatrix, PARALL
     }
 }
 
-impl<const PARALLEL: bool> LogLikelihood<ContinuousDataMatrix, PARALLEL> {
-    /// Computes LL given data set $\mathbf{D}$ and vertex $X$ and parents $\mathbf{Z}$.
-    #[inline]
-    pub fn call(&self, d: &ContinuousDataMatrix, x: usize, z: &[usize]) -> f64 {
-        match z.is_empty() {
-            true => MarginalLogLikelihood::<ContinuousDataMatrix, PARALLEL>::call(d, x),
-            false => ConditionalLogLikelihood::<ContinuousDataMatrix, PARALLEL>::call(d, x, z),
-        }
-    }
-}
-
 impl<G, const PARALLEL: bool> DecomposableScoringCriterion<ContinuousDataMatrix, G>
     for LogLikelihood<ContinuousDataMatrix, PARALLEL>
 where
@@ -117,6 +106,9 @@ where
 {
     #[inline]
     fn call(&self, d: &ContinuousDataMatrix, x: usize, z: &[usize]) -> f64 {
-        self.call(d, x, z)
+        match z.is_empty() {
+            true => MarginalLogLikelihood::<ContinuousDataMatrix, PARALLEL>::call(d, x),
+            false => ConditionalLogLikelihood::<ContinuousDataMatrix, PARALLEL>::call(d, x, z),
+        }
     }
 }

--- a/tests/discovery/hill_climbing.rs
+++ b/tests/discovery/hill_climbing.rs
@@ -78,6 +78,45 @@ mod categorical {
 
         assert_eq!(pred_g, true_g);
     }
+
+    #[test]
+    fn with_shuffle() {
+        // Set true graph.
+        let true_g = DiGraph::new(
+            ["A", "B", "D", "E", "L", "S", "T", "X"],
+            [
+                ("B", "S"),
+                ("D", "B"),
+                ("E", "B"),
+                ("E", "D"),
+                ("E", "L"),
+                ("E", "T"),
+                ("L", "S"),
+                ("T", "L"),
+                ("X", "E"),
+            ],
+        );
+
+        // Load data set.
+        let d = CsvReader::from_path("./tests/assets/asia.csv")
+            .unwrap()
+            .finish()
+            .unwrap();
+        let d = CategoricalDataMatrix::from(d);
+
+        // Initialize empty prior knowledge.
+        let k = FR::new(d.labels(), [], []);
+
+        // Initialize score functor.
+        let s = BIC::new();
+
+        // Initialize discovery functor.
+        let hc = HC::new(s).with_shuffle(42);
+        // Perform discovery.
+        let pred_g: DiGraph = hc.call(&d, &k);
+
+        assert_eq!(pred_g, true_g);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

Add `with_shuffle` method to `HillClimbing` algorithm to shuffle columns at the beginning, hence, shuffling edge operations.

Fixes #55 

## Pull Request Type

Choose the pull request type:

- [ ] Bug Fix,
- [x] Feature Addition,
- [ ] Other: _Add brief description_.

## Pull Request Checklist

Make sure that the following checklist is satisfied:

- [x] Pull request branch is `develop`,
- [x] Pull request description is written,
- [x] `Fixes #(ISSUE)` number is set,
- [x] `CONTRIBUTING` guidelines are satisfied:
  - [x] Build do not fail,
  - [x] Tests do not fail,
  - [x] Coverage is adequate,
  - [x] Code is properly linted,
  - [x] Code is properly formatted,
  - [x] Code is properly documented.

# Additional Details

## Testing

Tested against `bnlearn` implementation. Differs only for equivalent score edge operations. If the search space update is performed using `shift_remove` instead of `remove`, then it is exactly the same as `bnlearn` implementation. Unfortunately, this change would requires `O(n)` to update the search space instead of `O(1)`.
