### PR TITLE
Add DirectedGraph struct

### DIFF
--- a/src/directed_graph.rs
+++ b/src/directed_graph.rs
@@ -1,0 +1,62 @@
+use ndarray::Array2;
+
+/// A struct representing a directed graph using an adjacency matrix.
+///
+pub struct DirectedGraph {
+    adjacency_matrix: Array2<bool>,
+}
+
+impl DirectedGraph {
+    /// Creates a new directed graph with the given size.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The number of nodes in the graph.
+    ///
+    /// # Returns
+    ///
+    /// A new `DirectedGraph` instance.
+    ///
+    pub fn new(size: usize) -> Self {
+        Self {
+            adjacency_matrix: Array2::from_elem((size, size), false),
+        }
+    }
+
+    /// Checks if there is an edge between nodes `x` and `y`.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The first node.
+    /// * `y` - The second node.
+    ///
+    /// # Returns
+    ///
+    /// `true` if there is an edge between `x` and `y`, `false` otherwise.
+    ///
+    pub fn has_edge(&self, x: usize, y: usize) -> bool {
+        self.adjacency_matrix[[x, y]]
+    }
+
+    /// Adds an edge between nodes `x` and `y`.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The first node.
+    /// * `y` - The second node.
+    ///
+    pub fn add_edge(&mut self, x: usize, y: usize) {
+        self.adjacency_matrix[[x, y]] = true;
+    }
+
+    /// Removes the edge between nodes `x` and `y`.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The first node.
+    /// * `y` - The second node.
+    ///
+    pub fn del_edge(&mut self, x: usize, y: usize) {
+        self.adjacency_matrix[[x, y]] = false;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod undirected_graph;
+pub mod directed_graph;

--- a/tests/directed_graph.rs
+++ b/tests/directed_graph.rs
@@ -1,0 +1,28 @@
+#[cfg(test)]
+mod tests {
+    use causal_hub_next::directed_graph::DirectedGraph;
+
+    #[test]
+    fn test_has_edge() {
+        let mut graph = DirectedGraph::new(5);
+        graph.add_edge(0, 1);
+        assert!(graph.has_edge(0, 1));
+        assert!(!graph.has_edge(1, 0));
+        assert!(!graph.has_edge(0, 2));
+    }
+
+    #[test]
+    fn test_add_edge() {
+        let mut graph = DirectedGraph::new(5);
+        graph.add_edge(0, 1);
+        assert!(graph.has_edge(0, 1));
+    }
+
+    #[test]
+    fn test_del_edge() {
+        let mut graph = DirectedGraph::new(5);
+        graph.add_edge(0, 1);
+        graph.del_edge(0, 1);
+        assert!(!graph.has_edge(0, 1));
+    }
+}


### PR DESCRIPTION
Add a `DirectedGraph` struct and its methods.

* **DirectedGraph Struct**
  - Define a `DirectedGraph` struct with an `adjacency_matrix` field of type `Array2<bool>`.
  - Implement a `new` method to create a new graph with a given size.
  - Implement a `has_edge` method to check if there is an edge between two nodes.
  - Implement an `add_edge` method to add an edge between two nodes.
  - Implement a `del_edge` method to remove an edge between two nodes.

* **Module Declaration**
  - Add a new module declaration for `directed_graph` in `src/lib.rs`.

* **Tests**
  - Add a test for the `has_edge` method.
  - Add a test for the `add_edge` method.
  - Add a test for the `del_edge` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AlessioZanga/causal-hub-next/pull/2?shareId=747f0bda-183d-4716-831f-76321270f835).