### PR TITLE
Add neighbors, parents, and children methods to graphs

### DIFF
--- a/src/directed_graph.rs
+++ b/src/directed_graph.rs
@@ -106,4 +106,46 @@ impl DirectedGraph {
 
         true
     }
+
+    /// Returns the parents of a vertex.
+    ///
+    /// # Arguments
+    ///
+    /// * `vertex` - The vertex for which to find the parents.
+    ///
+    /// # Returns
+    ///
+    /// A vector of indices representing the parents of the vertex.
+    ///
+    pub fn parents(&self, vertex: usize) -> Vec<usize> {
+        // Check if the vertex is within bounds.
+        assert!(vertex < self.labels.len(), "Vertex {} index out of bounds", vertex);
+
+        // Use functional code to find the parents.
+        // Iterate over all vertices and filter the ones that are parents.
+        (0..self.labels.len())
+            .filter(|&i| self.adjacency_matrix[[i, vertex]])
+            .collect()
+    }
+
+    /// Returns the children of a vertex.
+    ///
+    /// # Arguments
+    ///
+    /// * `vertex` - The vertex for which to find the children.
+    ///
+    /// # Returns
+    ///
+    /// A vector of indices representing the children of the vertex.
+    ///
+    pub fn children(&self, vertex: usize) -> Vec<usize> {
+        // Check if the vertex is within bounds.
+        assert!(vertex < self.labels.len(), "Vertex {} index out of bounds", vertex);
+
+        // Use functional code to find the children.
+        // Iterate over all vertices and filter the ones that are children.
+        (0..self.labels.len())
+            .filter(|&i| self.adjacency_matrix[[vertex, i]])
+            .collect()
+    }
 }

--- a/src/directed_graph.rs
+++ b/src/directed_graph.rs
@@ -111,20 +111,21 @@ impl DirectedGraph {
     ///
     /// # Arguments
     ///
-    /// * `vertex` - The vertex for which to find the parents.
+    /// * `x` - The vertex for which to find the parents.
     ///
     /// # Returns
     ///
     /// A vector of indices representing the parents of the vertex.
     ///
-    pub fn parents(&self, vertex: usize) -> Vec<usize> {
+    pub fn parents(&self, x: usize) -> Vec<usize> {
         // Check if the vertex is within bounds.
-        assert!(vertex < self.labels.len(), "Vertex {} index out of bounds", vertex);
+        assert!(x < self.labels.len(), "Vertex {} index out of bounds", x);
 
-        // Use functional code to find the parents.
         // Iterate over all vertices and filter the ones that are parents.
-        (0..self.labels.len())
-            .filter(|&i| self.adjacency_matrix[[i, vertex]])
+        self.adjacency_matrix
+            .column(x)
+            .indexed_iter()
+            .filter_map(|(y, &has_edge)| if has_edge { Some(y) } else { None })
             .collect()
     }
 
@@ -132,20 +133,21 @@ impl DirectedGraph {
     ///
     /// # Arguments
     ///
-    /// * `vertex` - The vertex for which to find the children.
+    /// * `x` - The vertex for which to find the children.
     ///
     /// # Returns
     ///
     /// A vector of indices representing the children of the vertex.
     ///
-    pub fn children(&self, vertex: usize) -> Vec<usize> {
+    pub fn children(&self, x: usize) -> Vec<usize> {
         // Check if the vertex is within bounds.
-        assert!(vertex < self.labels.len(), "Vertex {} index out of bounds", vertex);
+        assert!(x < self.labels.len(), "Vertex {} index out of bounds", x);
 
-        // Use functional code to find the children.
         // Iterate over all vertices and filter the ones that are children.
-        (0..self.labels.len())
-            .filter(|&i| self.adjacency_matrix[[vertex, i]])
+        self.adjacency_matrix
+            .row(x)
+            .indexed_iter()
+            .filter_map(|(y, &has_edge)| if has_edge { Some(y) } else { None })
             .collect()
     }
 }

--- a/src/undirected_graph.rs
+++ b/src/undirected_graph.rs
@@ -108,4 +108,25 @@ impl UndirectedGraph {
 
         true
     }
+
+    /// Returns the neighbors of a vertex.
+    ///
+    /// # Arguments
+    ///
+    /// * `vertex` - The vertex for which to find the neighbors.
+    ///
+    /// # Returns
+    ///
+    /// A vector of indices representing the neighbors of the vertex.
+    ///
+    pub fn neighbors(&self, vertex: usize) -> Vec<usize> {
+        // Check if the vertex is within bounds.
+        assert!(vertex < self.labels.len(), "Vertex {} index out of bounds", vertex);
+
+        // Use functional code to find the neighbors.
+        // Iterate over all vertices and filter the ones that are neighbors.
+        (0..self.labels.len())
+            .filter(|&i| self.adjacency_matrix[[vertex, i]])
+            .collect()
+    }
 }

--- a/src/undirected_graph.rs
+++ b/src/undirected_graph.rs
@@ -113,20 +113,22 @@ impl UndirectedGraph {
     ///
     /// # Arguments
     ///
-    /// * `vertex` - The vertex for which to find the neighbors.
+    /// * `x` - The vertex for which to find the neighbors.
     ///
     /// # Returns
     ///
     /// A vector of indices representing the neighbors of the vertex.
     ///
-    pub fn neighbors(&self, vertex: usize) -> Vec<usize> {
+    pub fn neighbors(&self, x: usize) -> Vec<usize> {
         // Check if the vertex is within bounds.
-        assert!(vertex < self.labels.len(), "Vertex {} index out of bounds", vertex);
+        assert!(x < self.labels.len(), "Vertex {} index out of bounds", x);
 
-        // Use functional code to find the neighbors.
         // Iterate over all vertices and filter the ones that are neighbors.
-        (0..self.labels.len())
-            .filter(|&i| self.adjacency_matrix[[vertex, i]])
+        self.adjacency_matrix
+            .row(x)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(y, &has_edge)| if has_edge { Some(y) } else { None })
             .collect()
     }
 }

--- a/tests/directed_graph.rs
+++ b/tests/directed_graph.rs
@@ -69,4 +69,40 @@ mod tests {
         let mut graph = DirectedGraph::new(&LABELS);
         graph.del_edge(1, 5);
     }
+
+    #[test]
+    fn test_parents() {
+        let mut graph = DirectedGraph::new(&LABELS);
+        assert!(graph.add_edge(1, 0));
+        assert!(graph.add_edge(2, 0));
+        assert!(graph.add_edge(3, 0));
+        assert_eq!(graph.parents(0), vec![1, 2, 3]);
+        assert_eq!(graph.parents(1), vec![]);
+        assert_eq!(graph.parents(4), vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Vertex 5 index out of bounds")]
+    fn test_parents_out_of_bounds() {
+        let graph = DirectedGraph::new(&LABELS);
+        graph.parents(5);
+    }
+
+    #[test]
+    fn test_children() {
+        let mut graph = DirectedGraph::new(&LABELS);
+        assert!(graph.add_edge(0, 1));
+        assert!(graph.add_edge(0, 2));
+        assert!(graph.add_edge(0, 3));
+        assert_eq!(graph.children(0), vec![1, 2, 3]);
+        assert_eq!(graph.children(1), vec![]);
+        assert_eq!(graph.children(4), vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Vertex 5 index out of bounds")]
+    fn test_children_out_of_bounds() {
+        let graph = DirectedGraph::new(&LABELS);
+        graph.children(5);
+    }
 }

--- a/tests/undirected_graph.rs
+++ b/tests/undirected_graph.rs
@@ -71,4 +71,22 @@ mod tests {
         let mut graph = UndirectedGraph::new(&LABELS);
         graph.del_edge(1, 5);
     }
+
+    #[test]
+    fn test_neighbors() {
+        let mut graph = UndirectedGraph::new(&LABELS);
+        assert!(graph.add_edge(0, 1));
+        assert!(graph.add_edge(0, 2));
+        assert!(graph.add_edge(0, 3));
+        assert_eq!(graph.neighbors(0), vec![1, 2, 3]);
+        assert_eq!(graph.neighbors(1), vec![0]);
+        assert_eq!(graph.neighbors(4), vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Vertex 5 index out of bounds")]
+    fn test_neighbors_out_of_bounds() {
+        let graph = UndirectedGraph::new(&LABELS);
+        graph.neighbors(5);
+    }
 }


### PR DESCRIPTION
Add `neighbors` method for undirected graph and `parents` and `children` methods for directed graph.

* **Undirected Graph:**
  - Add `neighbors` method to return the neighbors of a vertex using functional code.
  - Sanitize the input to the `neighbors` method.
  - Comment each line of the `neighbors` method.

* **Directed Graph:**
  - Add `parents` method to return the parents of a vertex using functional code.
  - Add `children` method to return the children of a vertex using functional code.
  - Sanitize the inputs to the `parents` and `children` methods.
  - Comment each line of the `parents` and `children` methods.

* **Unit Tests:**
  - Add unit tests for the `neighbors` method in `tests/undirected_graph.rs`.
  - Add unit tests for the `parents` and `children` methods in `tests/directed_graph.rs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AlessioZanga/causal-hub-next/pull/4?shareId=626d5c69-7376-469e-9480-dcd22a6749aa).