### PR TITLE
Add Categorical struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,14 +27,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -63,6 +65,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,81 @@
 version = 4
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "causal-hub-next"
 version = "0.1.0"
 dependencies = [
+ "approx",
+ "fxhash",
+ "indexmap",
+ "itertools",
  "ndarray",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "indexmap"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,8 @@ authors = ["Alessio Zanga <alessio.zanga@outlook.it>"]
 edition = "2018"
 
 [dependencies]
-ndarray = "0.16.1"
+approx = "^0.5"
+fxhash = "^0.2"
+indexmap = "^2.8"
+itertools = "^0.14"
+ndarray = "^0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 
 [dependencies]
 ndarray = "0.15"
+serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,4 @@ authors = ["Alessio Zanga <alessio.zanga@outlook.it>"]
 edition = "2018"
 
 [dependencies]
-ndarray = "0.15"
-serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0"
+ndarray = "0.16.1"

--- a/src/categorical.rs
+++ b/src/categorical.rs
@@ -69,12 +69,13 @@ impl Categorical {
             states.iter().skip(1).map(|(_, i)| i.len()).product(),
             "Product of the number of states of the remaining variables does not match the number of rows."
         );
-        // Assert the probabilities sum to one by row.
+        // Assert the probabilities sum to one by row, unless empty.
         assert!(
-            probabilities
-                .sum_axis(Axis(1))
-                .iter()
-                .all(|&i| relative_eq!(i, 1.0)),
+            probabilities.is_empty()
+                || probabilities
+                    .sum_axis(Axis(1))
+                    .iter()
+                    .all(|&i| relative_eq!(i, 1.0)),
             "Probabilities must sum to one by row."
         );
 

--- a/src/categorical.rs
+++ b/src/categorical.rs
@@ -1,0 +1,32 @@
+use ndarray::Array2;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Categorical {
+    variables: Vec<(String, Vec<String>)>,
+    probabilities: Array2<f64>,
+}
+
+impl Categorical {
+    pub fn new(
+        variables: Vec<(String, Vec<String>)>,
+        probabilities: Array2<f64>,
+    ) -> Self {
+        Self {
+            variables,
+            probabilities,
+        }
+    }
+
+    pub fn get_probability(&self, state: Vec<usize>) -> f64 {
+        let mut index = 0;
+        let mut multiplier = 1;
+
+        for (i, &s) in state.iter().rev().enumerate() {
+            index += s * multiplier;
+            multiplier *= self.variables[i].1.len();
+        }
+
+        self.probabilities[[index / self.variables[0].1.len(), index % self.variables[0].1.len()]]
+    }
+}

--- a/src/categorical.rs
+++ b/src/categorical.rs
@@ -1,32 +1,86 @@
 use ndarray::Array2;
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+/// A struct representing a categorical distribution.
+///
 pub struct Categorical {
-    variables: Vec<(String, Vec<String>)>,
+    labels: Vec<String>,
+    states: Vec<Vec<String>>,
     probabilities: Array2<f64>,
 }
 
 impl Categorical {
-    pub fn new(
-        variables: Vec<(String, Vec<String>)>,
-        probabilities: Array2<f64>,
-    ) -> Self {
+    /// Creates a new categorical distribution.
+    ///
+    /// # Arguments
+    ///
+    /// * `variables` - The variables and their states.
+    /// * `probabilities` - The probabilities of the states.
+    ///
+    /// # Returns
+    ///
+    /// A new `Categorical` instance.
+    ///
+    pub fn new(variables: &[(&str, Vec<&str>)], probabilities: Array2<f64>) -> Self {
+        // Convert the array of string slices to a vector of strings.
+        let (labels, states): (Vec<_>, Vec<Vec<_>>) = {
+            (
+                // Get the labels of the variables.
+                variables.iter().map(|(i, _)| i.to_string()).collect(),
+                // Get the states of the variables.
+                variables
+                    .iter()
+                    .map(|(_, i)| i.iter().map(|s| s.to_string()).collect())
+                    .collect(),
+            )
+        };
+
+        // Check if the number of states of the first variable matches the number of columns.
+        assert_eq!(
+            probabilities.ncols(),
+            states.get(0).map(|i| i.len()).unwrap_or(0),
+            "Number of states of the first variable does not match the number of columns."
+        );
+        // Check if the product of the number of states of the remaining variables matches the number of rows.
+        assert_eq!(
+            probabilities.nrows(),
+            states.iter().skip(1).map(|i| i.len()).product(),
+            "Product of the number of states of the remaining variables does not match the number of rows."
+        );
+
         Self {
-            variables,
+            labels,
+            states,
             probabilities,
         }
     }
 
-    pub fn get_probability(&self, state: Vec<usize>) -> f64 {
-        let mut index = 0;
-        let mut multiplier = 1;
+    /// Returns the labels of the variables in the categorical distribution.
+    /// 
+    /// # Returns
+    /// 
+    /// A reference to the vector of labels.
+    /// 
+    pub fn labels(&self) -> &Vec<String> {
+        &self.labels
+    }
 
-        for (i, &s) in state.iter().rev().enumerate() {
-            index += s * multiplier;
-            multiplier *= self.variables[i].1.len();
-        }
+    /// Returns the states of the variables in the categorical distribution.
+    /// 
+    /// # Returns
+    /// 
+    /// A reference to the vector of states.
+    /// 
+    pub fn states(&self) -> &Vec<Vec<String>> {
+        &self.states
+    }
 
-        self.probabilities[[index / self.variables[0].1.len(), index % self.variables[0].1.len()]]
+    /// Returns the probabilities of the states in the categorical distribution.
+    /// 
+    /// # Returns
+    /// 
+    /// A reference to the array of probabilities.
+    /// 
+    pub fn probabilities(&self) -> &Array2<f64> {
+        &self.probabilities
     }
 }

--- a/src/categorical.rs
+++ b/src/categorical.rs
@@ -1,50 +1,81 @@
-use ndarray::Array2;
+use approx::relative_eq;
+use ndarray::{Array2, Axis};
+
+use crate::utils::{FxIndexMap, FxIndexSet};
 
 /// A struct representing a categorical distribution.
 ///
 pub struct Categorical {
-    labels: Vec<String>,
-    states: Vec<Vec<String>>,
+    labels: FxIndexSet<String>,
+    states: FxIndexMap<String, FxIndexSet<String>>,
     probabilities: Array2<f64>,
 }
 
 impl Categorical {
-    /// Creates a new categorical distribution.
+    /// Creates a new (conditional) categorical distribution.
     ///
     /// # Arguments
     ///
-    /// * `variables` - The variables and their states.
+    /// * `variables` - The variables and their states. Must be unique.
     /// * `probabilities` - The probabilities of the states.
+    ///
+    /// # Notes
+    ///
+    /// The first variable is the one conditioned on as P(X | Z).
     ///
     /// # Returns
     ///
     /// A new `Categorical` instance.
     ///
     pub fn new(variables: &[(&str, Vec<&str>)], probabilities: Array2<f64>) -> Self {
-        // Convert the array of string slices to a vector of strings.
-        let (labels, states): (Vec<_>, Vec<Vec<_>>) = {
-            (
-                // Get the labels of the variables.
-                variables.iter().map(|(i, _)| i.to_string()).collect(),
-                // Get the states of the variables.
-                variables
-                    .iter()
-                    .map(|(_, i)| i.iter().map(|s| s.to_string()).collect())
-                    .collect(),
-            )
-        };
+        // Get the states of the variables.
+        let states: FxIndexMap<_, FxIndexSet<_>> = variables
+            .iter()
+            .map(|(i, j)| {
+                (
+                    // Convert the variable label to a string.
+                    i.to_string(),
+                    // Convert the variable states to a set of strings.
+                    j.iter().map(|k| k.to_string()).collect(),
+                )
+            })
+            .collect();
+        // Get the labels of the variables.
+        let labels: FxIndexSet<_> = states.keys().cloned().collect();
+        // Check variables labels are unique.
+        assert_eq!(
+            states.len(),
+            variables.len(),
+            "Variable labels must be unique."
+        );
+        // Check variables states are unique.
+        assert!(
+            states
+                .values()
+                .map(|i| i.len())
+                .eq(variables.iter().map(|(_, i)| i.len())),
+            "Variable states must be unique."
+        );
 
         // Check if the number of states of the first variable matches the number of columns.
         assert_eq!(
             probabilities.ncols(),
-            states.get(0).map(|i| i.len()).unwrap_or(0),
+            states.get_index(0).map(|(_, i)| i.len()).unwrap_or(0),
             "Number of states of the first variable does not match the number of columns."
         );
         // Check if the product of the number of states of the remaining variables matches the number of rows.
         assert_eq!(
             probabilities.nrows(),
-            states.iter().skip(1).map(|i| i.len()).product(),
+            states.iter().skip(1).map(|(_, i)| i.len()).product(),
             "Product of the number of states of the remaining variables does not match the number of rows."
+        );
+        // Assert the probabilities sum to one by row.
+        assert!(
+            probabilities
+                .sum_axis(Axis(1))
+                .iter()
+                .all(|&i| relative_eq!(i, 1.0)),
+            "Probabilities must sum to one by row."
         );
 
         Self {
@@ -55,31 +86,31 @@ impl Categorical {
     }
 
     /// Returns the labels of the variables in the categorical distribution.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A reference to the vector of labels.
-    /// 
-    pub fn labels(&self) -> &Vec<String> {
+    ///
+    pub fn labels(&self) -> &FxIndexSet<String> {
         &self.labels
     }
 
     /// Returns the states of the variables in the categorical distribution.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A reference to the vector of states.
-    /// 
-    pub fn states(&self) -> &Vec<Vec<String>> {
+    ///
+    pub fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
         &self.states
     }
 
     /// Returns the probabilities of the states in the categorical distribution.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A reference to the array of probabilities.
-    /// 
+    ///
     pub fn probabilities(&self) -> &Array2<f64> {
         &self.probabilities
     }

--- a/src/directed_graph.rs
+++ b/src/directed_graph.rs
@@ -1,9 +1,11 @@
 use ndarray::Array2;
 
+use crate::utils::FxIndexSet;
+
 /// A struct representing a directed graph using an adjacency matrix.
 ///
 pub struct DirectedGraph {
-    labels: Vec<String>,
+    labels: FxIndexSet<String>,
     adjacency_matrix: Array2<bool>,
 }
 
@@ -12,17 +14,20 @@ impl DirectedGraph {
     ///
     /// # Arguments
     ///
-    /// * `labels` - The labels of the vertices in the graph.
+    /// * `labels` - The labels of the vertices in the graph. Must be unique.
     ///
     /// # Returns
     ///
     /// A new `DirectedGraph` instance.
     ///
     pub fn new(labels: &[&str]) -> Self {
-        // Convert the array of string slices to a vector of strings.
-        let labels: Vec<_> = labels.iter().map(|s| s.to_string()).collect();
         // Get the size of the graph from the number of labels.
         let size = labels.len();
+        // Convert the array of string slices to a vector of strings.
+        let labels: FxIndexSet<_> = labels.iter().map(|s| s.to_string()).collect();
+        // Assert no duplicate labels.
+        assert_eq!(size, labels.len(), "Labels must be unique.");
+
         // Initialize the adjacency matrix with `false` values.
         let adjacency_matrix = Array2::from_elem((size, size), false);
 
@@ -38,7 +43,7 @@ impl DirectedGraph {
     ///
     /// A reference to the vector of labels.
     ///
-    pub fn labels(&self) -> &Vec<String> {
+    pub fn labels(&self) -> &FxIndexSet<String> {
         &self.labels
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod undirected_graph;
 pub mod directed_graph;
+pub mod categorical;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
-pub mod undirected_graph;
-pub mod directed_graph;
 pub mod categorical;
+pub mod directed_graph;
+pub mod undirected_graph;
+pub mod utils;

--- a/src/undirected_graph.rs
+++ b/src/undirected_graph.rs
@@ -1,9 +1,11 @@
 use ndarray::Array2;
 
+use crate::utils::FxIndexSet;
+
 /// A struct representing an undirected graph using an adjacency matrix.
 ///
 pub struct UndirectedGraph {
-    labels: Vec<String>,
+    labels: FxIndexSet<String>,
     adjacency_matrix: Array2<bool>,
 }
 
@@ -12,17 +14,20 @@ impl UndirectedGraph {
     ///
     /// # Arguments
     ///
-    /// * `labels` - The labels of the vertices in the graph.
+    /// * `labels` - The labels of the vertices in the graph. Must be unique.
     ///
     /// # Returns
     ///
     /// A new `UndirectedGraph` instance.
     ///
     pub fn new(labels: &[&str]) -> Self {
-        // Convert the array of string slices to a vector of strings.
-        let labels: Vec<_> = labels.iter().map(|s| s.to_string()).collect();
         // Get the size of the graph from the number of labels.
         let size = labels.len();
+        // Convert the array of string slices to a vector of strings.
+        let labels: FxIndexSet<_> = labels.iter().map(|s| s.to_string()).collect();
+        // Assert no duplicate labels.
+        assert_eq!(size, labels.len(), "Labels must be unique.");
+
         // Initialize the adjacency matrix with `false` values.
         let adjacency_matrix = Array2::from_elem((size, size), false);
 
@@ -38,7 +43,7 @@ impl UndirectedGraph {
     ///
     /// A reference to the vector of labels.
     ///
-    pub fn labels(&self) -> &Vec<String> {
+    pub fn labels(&self) -> &FxIndexSet<String> {
         &self.labels
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,5 @@
+use fxhash::FxBuildHasher;
+use indexmap::{IndexMap, IndexSet};
+
+pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
+pub type FxIndexSet<T> = IndexSet<T, FxBuildHasher>;

--- a/tests/categorical.rs
+++ b/tests/categorical.rs
@@ -13,4 +13,34 @@ mod tests {
         let probabilities = array![[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]];
         let categorical = Categorical::new(&variables, probabilities);
     }
+
+    #[test]
+    #[should_panic(expected = "Variable labels must be unique.")]
+    fn test_unique_labels() {
+        let variables = vec![
+            ("A", vec!["no", "yes"]),
+            ("A", vec!["no", "yes"]),
+        ];
+        let probabilities = array![[0.1, 0.9], [0.2, 0.8]];
+        Categorical::new(&variables, probabilities);
+    }
+
+    #[test]
+    #[should_panic(expected = "Variable states must be unique.")]
+    fn test_unique_states() {
+        let variables = vec![
+            ("A", vec!["no", "no"]),
+            ("B", vec!["no", "yes"]),
+        ];
+        let probabilities = array![[0.1, 0.9], [0.2, 0.8]];
+        Categorical::new(&variables, probabilities);
+    }
+
+    #[test]
+    #[should_panic(expected = "Variable labels must be unique.")]
+    fn test_empty_labels() {
+        let variables = vec![];
+        let probabilities = array![];
+        Categorical::new(&variables, probabilities);
+    }
 }

--- a/tests/categorical.rs
+++ b/tests/categorical.rs
@@ -17,10 +17,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Variable labels must be unique.")]
     fn test_unique_labels() {
-        let variables = vec![
-            ("A", vec!["no", "yes"]),
-            ("A", vec!["no", "yes"]),
-        ];
+        let variables = vec![("A", vec!["no", "yes"]), ("A", vec!["no", "yes"])];
         let probabilities = array![[0.1, 0.9], [0.2, 0.8]];
         Categorical::new(&variables, probabilities);
     }
@@ -28,19 +25,15 @@ mod tests {
     #[test]
     #[should_panic(expected = "Variable states must be unique.")]
     fn test_unique_states() {
-        let variables = vec![
-            ("A", vec!["no", "no"]),
-            ("B", vec!["no", "yes"]),
-        ];
+        let variables = vec![("A", vec!["no", "no"]), ("B", vec!["no", "yes"])];
         let probabilities = array![[0.1, 0.9], [0.2, 0.8]];
         Categorical::new(&variables, probabilities);
     }
 
     #[test]
-    #[should_panic(expected = "Variable labels must be unique.")]
     fn test_empty_labels() {
         let variables = vec![];
-        let probabilities = array![];
+        let probabilities = array![[]];
         Categorical::new(&variables, probabilities);
     }
 }

--- a/tests/categorical.rs
+++ b/tests/categorical.rs
@@ -6,19 +6,11 @@ mod tests {
     #[test]
     fn test_get_probability() {
         let variables = vec![
-            ("A".to_string(), vec!["a1".to_string(), "a2".to_string()]),
-            ("B".to_string(), vec!["b1".to_string(), "b2".to_string()]),
+            ("A", vec!["no", "yes"]),
+            ("B", vec!["no", "yes"]),
+            ("C", vec!["no", "yes"]),
         ];
         let probabilities = array![[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]];
-        let categorical = Categorical::new(variables, probabilities);
-
-        assert_eq!(categorical.get_probability(vec![0, 0]), 0.1);
-        assert_eq!(categorical.get_probability(vec![0, 1]), 0.9);
-        assert_eq!(categorical.get_probability(vec![1, 0]), 0.2);
-        assert_eq!(categorical.get_probability(vec![1, 1]), 0.8);
-        assert_eq!(categorical.get_probability(vec![2, 0]), 0.3);
-        assert_eq!(categorical.get_probability(vec![2, 1]), 0.7);
-        assert_eq!(categorical.get_probability(vec![3, 0]), 0.4);
-        assert_eq!(categorical.get_probability(vec![3, 1]), 0.6);
+        let categorical = Categorical::new(&variables, probabilities);
     }
 }

--- a/tests/categorical.rs
+++ b/tests/categorical.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod tests {
+    use causal_hub_next::categorical::Categorical;
+    use ndarray::array;
+
+    #[test]
+    fn test_get_probability() {
+        let variables = vec![
+            ("A".to_string(), vec!["a1".to_string(), "a2".to_string()]),
+            ("B".to_string(), vec!["b1".to_string(), "b2".to_string()]),
+        ];
+        let probabilities = array![[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]];
+        let categorical = Categorical::new(variables, probabilities);
+
+        assert_eq!(categorical.get_probability(vec![0, 0]), 0.1);
+        assert_eq!(categorical.get_probability(vec![0, 1]), 0.9);
+        assert_eq!(categorical.get_probability(vec![1, 0]), 0.2);
+        assert_eq!(categorical.get_probability(vec![1, 1]), 0.8);
+        assert_eq!(categorical.get_probability(vec![2, 0]), 0.3);
+        assert_eq!(categorical.get_probability(vec![2, 1]), 0.7);
+        assert_eq!(categorical.get_probability(vec![3, 0]), 0.4);
+        assert_eq!(categorical.get_probability(vec![3, 1]), 0.6);
+    }
+}

--- a/tests/directed_graph.rs
+++ b/tests/directed_graph.rs
@@ -114,7 +114,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Labels must be unique.")]
     fn test_empty_labels() {
         let labels: [&str; 0] = [];
         DirectedGraph::new(&labels);

--- a/tests/directed_graph.rs
+++ b/tests/directed_graph.rs
@@ -105,4 +105,18 @@ mod tests {
         let graph = DirectedGraph::new(&LABELS);
         graph.children(5);
     }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_unique_labels() {
+        let labels = ["A", "A", "B"];
+        DirectedGraph::new(&labels);
+    }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_empty_labels() {
+        let labels: [&str; 0] = [];
+        DirectedGraph::new(&labels);
+    }
 }

--- a/tests/undirected_graph.rs
+++ b/tests/undirected_graph.rs
@@ -89,4 +89,18 @@ mod tests {
         let graph = UndirectedGraph::new(&LABELS);
         graph.neighbors(5);
     }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_unique_labels() {
+        let labels = ["A", "A", "B"];
+        UndirectedGraph::new(&labels);
+    }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_empty_labels() {
+        let labels: [&str; 0] = [];
+        UndirectedGraph::new(&labels);
+    }
 }

--- a/tests/undirected_graph.rs
+++ b/tests/undirected_graph.rs
@@ -98,7 +98,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Labels must be unique.")]
     fn test_empty_labels() {
         let labels: [&str; 0] = [];
         UndirectedGraph::new(&labels);


### PR DESCRIPTION
Add a `Categorical` struct to represent a multivariate conditional categorical probability distribution.

* **Cargo.toml**
  - Add `serde` and `serde_derive` dependencies.

* **src/lib.rs**
  - Add a module declaration for `categorical`.

* **src/categorical.rs**
  - Define a `Categorical` struct with `variables` and `probabilities` fields.
  - Implement a constructor for `Categorical` that takes a vector of tuples and a 2D ndarray.
  - Implement a method to get the probability of a given state.

* **tests/categorical.rs**
  - Add unit tests for the `Categorical` struct.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AlessioZanga/causal-hub-next/pull/5?shareId=dcc0a0e4-b1b4-4922-ab66-1d8333dec30a).