### PR TITLE
Add edge cases for unique labels and empty labels vectors

### DIFF
--- a/tests/categorical.rs
+++ b/tests/categorical.rs
@@ -13,4 +13,34 @@ mod tests {
         let probabilities = array![[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]];
         let categorical = Categorical::new(&variables, probabilities);
     }
+
+    #[test]
+    #[should_panic(expected = "Variable labels must be unique.")]
+    fn test_unique_labels() {
+        let variables = vec![
+            ("A", vec!["no", "yes"]),
+            ("A", vec!["no", "yes"]),
+        ];
+        let probabilities = array![[0.1, 0.9], [0.2, 0.8]];
+        Categorical::new(&variables, probabilities);
+    }
+
+    #[test]
+    #[should_panic(expected = "Variable states must be unique.")]
+    fn test_unique_states() {
+        let variables = vec![
+            ("A", vec!["no", "no"]),
+            ("B", vec!["no", "yes"]),
+        ];
+        let probabilities = array![[0.1, 0.9], [0.2, 0.8]];
+        Categorical::new(&variables, probabilities);
+    }
+
+    #[test]
+    #[should_panic(expected = "Variable labels must be unique.")]
+    fn test_empty_labels() {
+        let variables = vec![];
+        let probabilities = array![];
+        Categorical::new(&variables, probabilities);
+    }
 }

--- a/tests/directed_graph.rs
+++ b/tests/directed_graph.rs
@@ -105,4 +105,18 @@ mod tests {
         let graph = DirectedGraph::new(&LABELS);
         graph.children(5);
     }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_unique_labels() {
+        let labels = ["A", "A", "B"];
+        DirectedGraph::new(&labels);
+    }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_empty_labels() {
+        let labels: [&str; 0] = [];
+        DirectedGraph::new(&labels);
+    }
 }

--- a/tests/undirected_graph.rs
+++ b/tests/undirected_graph.rs
@@ -89,4 +89,18 @@ mod tests {
         let graph = UndirectedGraph::new(&LABELS);
         graph.neighbors(5);
     }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_unique_labels() {
+        let labels = ["A", "A", "B"];
+        UndirectedGraph::new(&labels);
+    }
+
+    #[test]
+    #[should_panic(expected = "Labels must be unique.")]
+    fn test_empty_labels() {
+        let labels: [&str; 0] = [];
+        UndirectedGraph::new(&labels);
+    }
 }


### PR DESCRIPTION
Add tests to check for unique labels and empty labels vectors in `Categorical`, `DirectedGraph`, and `UndirectedGraph`.

* **Categorical Tests**
  - Add a test to check for unique labels in `Categorical::new`.
  - Add a test to check for unique states in `Categorical::new`.
  - Add a test to check for empty labels vector in `Categorical::new`.

* **DirectedGraph Tests**
  - Add a test to check for unique labels in `DirectedGraph::new`.
  - Add a test to check for empty labels vector in `DirectedGraph::new`.

* **UndirectedGraph Tests**
  - Add a test to check for unique labels in `UndirectedGraph::new`.
  - Add a test to check for empty labels vector in `UndirectedGraph::new`.

