### PR TITLE
Add prior knowledge for structure learning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cpufeatures"
@@ -217,7 +217,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -246,9 +246,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -288,9 +288,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -429,9 +429,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
@@ -463,20 +463,19 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -530,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f239d656363bcee73afef85277f1b281e8ac6212a1d42aa90e55b90ed43c47a4"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
  "indoc",
  "libc",
@@ -548,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755ea671a1c34044fa165247aaf6f419ca39caa6003aee791a0df2713d8f1b6d"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -558,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc95a2e67091e44791d4ea300ff744be5293f394f1bafd9f78c080814d35956e"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -579,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a179641d1b93920829a62f15e87c0ed791b6c8db2271ba0fd7c2686090510214"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -591,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dff85ebcaab8c441b0e3f7ae40a6963ecea8a9f5e74f647e33fcf5ec9a1e89e"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -613,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -788,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -855,9 +854,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -879,18 +878,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "approx",
  "causal-hub",
  "dry",
+ "log",
  "numpy",
  "paste",
  "pyo3",

--- a/causal-hub/src/assets/mod.rs
+++ b/causal-hub/src/assets/mod.rs
@@ -1,4 +1,5 @@
 use dry::macro_for;
+use log::debug;
 use ndarray::prelude::*;
 use paste::paste;
 
@@ -18,18 +19,23 @@ macro_for!(
     paste! {
         #[doc = "Load the `" $bn:upper "` BN from the assets."]
         pub fn [<load_ $bn>]() -> CatBN {
+            // Log the loading of the BN.
+            debug!("Loading the '{}' BN from assets.", stringify!($bn));
+            // Read the BIF file and return the BN.
             BifReader::read(include_str!(concat!(stringify!($bn), ".bif")))
         }
     }
 });
 
-/// Load the EATING CTBN.
+/// Load the 'eating' CTBN.
 ///
 /// See:
 ///     U. Nodelman, C.R. Shelton, and D. Koller (2003). "Learning Continuous Time Bayesian Networks."
 ///     Proc. Nineteenth Conference on Uncertainty in Artificial Intelligence (UAI) (pp. 451-458).
 ///
 pub fn load_eating() -> CatCTBN {
+    // Log the loading of the EATING CTBN.
+    debug!("Loading the 'eating' CTBN from assets.");
     // Initialize the graph.
     let mut graph = DiGraph::empty(vec!["Hungry", "Eating", "FullStomach"]);
     graph.add_edge(0, 1); // Hungry -> Eating

--- a/causal-hub/src/datasets/categorical/dataset.rs
+++ b/causal-hub/src/datasets/categorical/dataset.rs
@@ -259,11 +259,10 @@ impl Display for CatData {
 }
 
 impl Dataset for CatData {
-    type Labels = Labels;
     type Values = Array2<u8>;
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         &self.labels
     }
 

--- a/causal-hub/src/datasets/categorical/evidence.rs
+++ b/causal-hub/src/datasets/categorical/evidence.rs
@@ -3,7 +3,7 @@ use ndarray::prelude::*;
 
 use crate::{
     datasets::CatTrjEvT,
-    types::{FxIndexMap, FxIndexSet},
+    types::{FxIndexMap, FxIndexSet, Labels, States},
     utils::{collect_states, sort_states},
 };
 
@@ -89,8 +89,8 @@ impl CatEvT {
 /// Categorical evidence structure.
 #[derive(Clone, Debug)]
 pub struct CategoricalEvidence {
-    labels: FxIndexSet<String>,
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    labels: Labels,
+    states: States,
     cardinality: Array1<usize>,
     evidences: FxIndexMap<String, Option<CatEvT>>,
 }
@@ -260,7 +260,7 @@ impl CategoricalEvidence {
     /// A reference to the labels of the evidence.
     ///
     #[inline]
-    pub const fn labels(&self) -> &FxIndexSet<String> {
+    pub const fn labels(&self) -> &Labels {
         &self.labels
     }
 
@@ -271,7 +271,7 @@ impl CategoricalEvidence {
     /// A reference to the states of the evidence.
     ///
     #[inline]
-    pub const fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn states(&self) -> &States {
         &self.states
     }
 

--- a/causal-hub/src/datasets/categorical/incomplete.rs
+++ b/causal-hub/src/datasets/categorical/incomplete.rs
@@ -1,7 +1,7 @@
 use ndarray::prelude::*;
 
 use super::CatSample;
-use crate::types::{FxIndexMap, FxIndexSet};
+use crate::types::{Labels, States};
 
 /// A struct representing a categorical incomplete sample.
 #[derive(Clone, Debug)]
@@ -15,8 +15,8 @@ pub type CatIncSample = CategoricalIncompleteSample;
 /// A struct representing a categorical incomplete dataset.
 #[derive(Clone, Debug)]
 pub struct CategoricalIncompleteDataset {
-    labels: FxIndexSet<String>,
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    labels: Labels,
+    states: States,
     cardinality: Array1<usize>,
     values: Array2<u8>,
 }

--- a/causal-hub/src/datasets/categorical/weighted.rs
+++ b/causal-hub/src/datasets/categorical/weighted.rs
@@ -1,7 +1,7 @@
 use ndarray::prelude::*;
 
 use super::CatSample;
-use crate::types::{FxIndexMap, FxIndexSet};
+use crate::types::{Labels, States};
 
 /// A struct representing a categorical weighted sample.
 #[derive(Clone, Debug)]
@@ -18,8 +18,8 @@ pub type CatWtdSample = CategoricalWeightedSample;
 /// A struct representing a dataset of categorical weighted samples.
 #[derive(Clone, Debug)]
 pub struct CategoricalWeightedDataset {
-    labels: FxIndexSet<String>,
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    labels: Labels,
+    states: States,
     cardinality: Array1<usize>,
     values: Vec<CatWtdSample>,
 }

--- a/causal-hub/src/datasets/mod.rs
+++ b/causal-hub/src/datasets/mod.rs
@@ -4,10 +4,10 @@ pub use categorical::*;
 mod trajectory;
 pub use trajectory::*;
 
+use crate::types::Labels;
+
 /// A trait for dataset.
 pub trait Dataset {
-    /// The type of the labels.
-    type Labels;
     /// The type of the values.
     type Values;
 
@@ -17,7 +17,7 @@ pub trait Dataset {
     ///
     /// A reference to the labels.
     ///
-    fn labels(&self) -> &Self::Labels;
+    fn labels(&self) -> &Labels;
 
     /// The values of the variables.
     ///

--- a/causal-hub/src/datasets/trajectory/dataset.rs
+++ b/causal-hub/src/datasets/trajectory/dataset.rs
@@ -165,11 +165,10 @@ impl CatTrj {
 }
 
 impl Dataset for CatTrj {
-    type Labels = Labels;
     type Values = Array2<u8>;
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         self.events.labels()
     }
 
@@ -317,11 +316,10 @@ impl<'a> IntoParallelRefIterator<'a> for CatTrjs {
 }
 
 impl Dataset for CatTrjs {
-    type Labels = Labels;
     type Values = Vec<CatTrj>;
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         &self.labels
     }
 

--- a/causal-hub/src/datasets/trajectory/dataset.rs
+++ b/causal-hub/src/datasets/trajectory/dataset.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 
 use crate::{
     datasets::{CatData, Dataset},
-    types::{FxIndexMap, FxIndexSet},
+    types::{Labels, States},
 };
 
 /// A multivariate trajectory.
@@ -137,7 +137,7 @@ impl CatTrj {
     /// A reference to the states of the trajectory.
     ///
     #[inline]
-    pub const fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn states(&self) -> &States {
         self.events.states()
     }
 
@@ -165,7 +165,7 @@ impl CatTrj {
 }
 
 impl Dataset for CatTrj {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Values = Array2<u8>;
 
     #[inline]
@@ -187,8 +187,8 @@ impl Dataset for CatTrj {
 /// A collection of multivariate trajectories.
 #[derive(Clone, Debug)]
 pub struct CategoricalTrajectories {
-    labels: FxIndexSet<String>,
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    labels: Labels,
+    states: States,
     cardinality: Array1<usize>,
     values: Vec<CatTrj>,
 }
@@ -266,7 +266,7 @@ impl CatTrjs {
     /// A reference to the states of the trajectories.
     ///
     #[inline]
-    pub fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub fn states(&self) -> &States {
         &self.states
     }
 
@@ -317,7 +317,7 @@ impl<'a> IntoParallelRefIterator<'a> for CatTrjs {
 }
 
 impl Dataset for CatTrjs {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Values = Vec<CatTrj>;
 
     #[inline]

--- a/causal-hub/src/datasets/trajectory/evidence.rs
+++ b/causal-hub/src/datasets/trajectory/evidence.rs
@@ -547,11 +547,10 @@ impl CatTrjEv {
 }
 
 impl Dataset for CatTrjEv {
-    type Labels = Labels;
     type Values = FxIndexMap<String, Vec<CatTrjEvT>>;
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         &self.labels
     }
 
@@ -699,11 +698,10 @@ impl<'a> IntoParallelRefIterator<'a> for CatTrjsEv {
 }
 
 impl Dataset for CatTrjsEv {
-    type Labels = Labels;
     type Values = Vec<CatTrjEv>;
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         &self.labels
     }
 

--- a/causal-hub/src/datasets/trajectory/evidence.rs
+++ b/causal-hub/src/datasets/trajectory/evidence.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     datasets::{CatEv, Dataset},
-    types::{EPSILON, FxIndexMap, FxIndexSet},
+    types::{EPSILON, FxIndexMap, FxIndexSet, Labels, States},
     utils::{collect_states, sort_states},
 };
 
@@ -125,8 +125,8 @@ impl CatTrjEvT {
 /// A type representing a collection of evidences for a categorical trajectory.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CategoricalTrajectoryEvidence {
-    labels: FxIndexSet<String>,
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    labels: Labels,
+    states: States,
     cardinality: Array1<usize>,
     evidences: FxIndexMap<String, Vec<CatTrjEvT>>,
 }
@@ -506,7 +506,7 @@ impl CatTrjEv {
     /// A reference to the states of the trajectory evidence.
     ///
     #[inline]
-    pub const fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn states(&self) -> &States {
         &self.states
     }
 
@@ -547,7 +547,7 @@ impl CatTrjEv {
 }
 
 impl Dataset for CatTrjEv {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Values = FxIndexMap<String, Vec<CatTrjEvT>>;
 
     #[inline]
@@ -569,8 +569,8 @@ impl Dataset for CatTrjEv {
 /// A collection of multivariate trajectories evidence.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CategoricalTrajectoriesEvidence {
-    labels: FxIndexSet<String>,
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    labels: Labels,
+    states: States,
     cardinality: Array1<usize>,
     values: Vec<CatTrjEv>,
 }
@@ -648,7 +648,7 @@ impl CatTrjsEv {
     /// A reference to the states of the trajectories evidence.
     ///
     #[inline]
-    pub fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub fn states(&self) -> &States {
         &self.states
     }
 
@@ -699,7 +699,7 @@ impl<'a> IntoParallelRefIterator<'a> for CatTrjsEv {
 }
 
 impl Dataset for CatTrjsEv {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Values = Vec<CatTrjEv>;
 
     #[inline]

--- a/causal-hub/src/datasets/trajectory/weighted.rs
+++ b/causal-hub/src/datasets/trajectory/weighted.rs
@@ -113,11 +113,10 @@ impl CatWtdTrj {
 }
 
 impl Dataset for CatWtdTrj {
-    type Labels = Labels;
     type Values = Array2<u8>;
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         self.trajectory.labels()
     }
 
@@ -265,11 +264,10 @@ impl<'a> IntoParallelRefIterator<'a> for CatWtdTrjs {
 }
 
 impl Dataset for CatWtdTrjs {
-    type Labels = Labels;
     type Values = Vec<CatWtdTrj>;
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         &self.labels
     }
 

--- a/causal-hub/src/datasets/trajectory/weighted.rs
+++ b/causal-hub/src/datasets/trajectory/weighted.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 use super::CatTrj;
 use crate::{
     datasets::Dataset,
-    types::{FxIndexMap, FxIndexSet},
+    types::{Labels, States},
 };
 
 /// A multivariate weighted trajectory.
@@ -85,7 +85,7 @@ impl CatWtdTrj {
     /// A reference to the states of the trajectory.
     ///
     #[inline]
-    pub const fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn states(&self) -> &States {
         self.trajectory.states()
     }
 
@@ -113,7 +113,7 @@ impl CatWtdTrj {
 }
 
 impl Dataset for CatWtdTrj {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Values = Array2<u8>;
 
     #[inline]
@@ -135,8 +135,8 @@ impl Dataset for CatWtdTrj {
 /// A collection of weighted trajectories.
 #[derive(Clone, Debug)]
 pub struct CategoricalWeightedTrajectories {
-    labels: FxIndexSet<String>,
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    labels: Labels,
+    states: States,
     cardinality: Array1<usize>,
     values: Vec<CatWtdTrj>,
 }
@@ -214,7 +214,7 @@ impl CatWtdTrjs {
     /// A reference to the states of the trajectories.
     ///
     #[inline]
-    pub fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub fn states(&self) -> &States {
         &self.states
     }
 
@@ -265,7 +265,7 @@ impl<'a> IntoParallelRefIterator<'a> for CatWtdTrjs {
 }
 
 impl Dataset for CatWtdTrjs {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Values = Vec<CatWtdTrj>;
 
     #[inline]

--- a/causal-hub/src/distributions/categorical.rs
+++ b/causal-hub/src/distributions/categorical.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::CPD;
 use crate::{
-    types::{EPSILON, FxIndexMap, FxIndexSet},
+    types::{EPSILON, FxIndexSet, Labels, States},
     utils::{RMI, collect_states},
 };
 
@@ -19,8 +19,8 @@ pub struct CategoricalConditionalProbabilityDistribution {
     states: FxIndexSet<String>,
     cardinality: usize,
     // Labels of the conditioning variables.
-    conditioning_labels: FxIndexSet<String>,
-    conditioning_states: FxIndexMap<String, FxIndexSet<String>>,
+    conditioning_labels: Labels,
+    conditioning_states: States,
     conditioning_cardinality: Array1<usize>,
     // Ravel multi index.
     ravel_multi_index: RMI,
@@ -260,7 +260,7 @@ impl CatCPD {
     /// The states of the conditioning variables.
     ///
     #[inline]
-    pub const fn conditioning_states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn conditioning_states(&self) -> &States {
         &self.conditioning_states
     }
 
@@ -507,7 +507,7 @@ impl RelativeEq for CatCPD {
 
 impl CPD for CatCPD {
     type Label = String;
-    type ConditioningLabels = FxIndexSet<String>;
+    type ConditioningLabels = Labels;
     type Parameters = Array2<f64>;
     type SS = (Array2<f64>, Array1<f64>, f64);
 

--- a/causal-hub/src/distributions/intensity_matrix.rs
+++ b/causal-hub/src/distributions/intensity_matrix.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::CPD;
 use crate::{
-    types::{EPSILON, FxIndexMap, FxIndexSet},
+    types::{EPSILON, FxIndexSet, Labels, States},
     utils::{RMI, collect_states},
 };
 
@@ -16,8 +16,8 @@ pub struct CategoricalConditionalIntensityMatrix {
     states: FxIndexSet<String>,
     cardinality: usize,
     // Labels of the conditioning variables.
-    conditioning_labels: FxIndexSet<String>,
-    conditioning_states: FxIndexMap<String, FxIndexSet<String>>,
+    conditioning_labels: Labels,
+    conditioning_states: States,
     conditioning_cardinality: Array1<usize>,
     // Ravel multi index.
     ravel_multi_index: RMI,
@@ -213,7 +213,7 @@ impl CatCIM {
     /// The states of the conditioning variables.
     ///
     #[inline]
-    pub const fn conditioning_states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn conditioning_states(&self) -> &States {
         &self.conditioning_states
     }
 
@@ -395,7 +395,7 @@ impl RelativeEq for CatCIM {
 
 impl CPD for CatCIM {
     type Label = String;
-    type ConditioningLabels = FxIndexSet<String>;
+    type ConditioningLabels = Labels;
     type Parameters = Array3<f64>;
     type SS = (Array3<f64>, Array2<f64>, f64);
 

--- a/causal-hub/src/estimators/parameters/bayesian.rs
+++ b/causal-hub/src/estimators/parameters/bayesian.rs
@@ -4,9 +4,9 @@ use statrs::function::gamma::ln_gamma;
 
 use super::{CPDEstimator, CSSEstimator, ParCPDEstimator, ParCSSEstimator, SSE};
 use crate::{
-    datasets::{CatData, CatTrj, CatTrjs, CatWtdTrj, CatWtdTrjs},
+    datasets::{CatData, CatTrj, CatTrjs, CatWtdTrj, CatWtdTrjs, Dataset},
     distributions::{CPD, CatCIM, CatCPD},
-    types::States,
+    types::{Labels, States},
 };
 
 /// A struct representing a Bayesian estimator.
@@ -50,6 +50,11 @@ impl<'a, D, Pi> BayesianEstimator<'a, D, Pi> {
 
 // NOTE: The prior is expressed as a scalar, which is the alpha for the Dirichlet distribution.
 impl CPDEstimator<CatCPD> for BE<'_, CatData, usize> {
+    #[inline]
+    fn labels(&self) -> &Labels {
+        self.dataset.labels()
+    }
+
     fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCPD as CPD>::SS, CatCPD) {
         // Get states and cardinality.
         let (states, cards) = (self.dataset.states(), self.dataset.cardinality());
@@ -190,6 +195,11 @@ impl BE<'_, CatTrj, (usize, f64)> {
 macro_for!($type in [CatTrj, CatWtdTrj, CatTrjs, CatWtdTrjs] {
 
     impl CPDEstimator<CatCIM> for BE<'_, $type, (usize, f64)> {
+        #[inline]
+        fn labels(&self) -> &Labels {
+            self.dataset.labels()
+        }
+
         fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
             // Get (states, prior).
             let (states, prior) = (self.dataset.states(), *self.prior());

--- a/causal-hub/src/estimators/parameters/bayesian.rs
+++ b/causal-hub/src/estimators/parameters/bayesian.rs
@@ -6,7 +6,7 @@ use super::{CPDEstimator, CSSEstimator, ParCPDEstimator, ParCSSEstimator, SSE};
 use crate::{
     datasets::{CatData, CatTrj, CatTrjs, CatWtdTrj, CatWtdTrjs},
     distributions::{CPD, CatCIM, CatCPD},
-    types::{FxIndexMap, FxIndexSet},
+    types::States,
 };
 
 /// A struct representing a Bayesian estimator.
@@ -110,7 +110,7 @@ impl BE<'_, CatTrj, (usize, f64)> {
         t_xz: Array2<f64>,
         n: f64,
         prior: (usize, f64),
-        states: &FxIndexMap<String, FxIndexSet<String>>,
+        states: &States,
     ) -> ((Array3<f64>, Array2<f64>, f64), CatCIM) {
         // Get the prior, as the alpha of Dirichlet and tau of Gamma.
         let (alpha, tau) = prior;
@@ -158,8 +158,8 @@ impl BE<'_, CatTrj, (usize, f64)> {
             // Compute the sample log-likelihood.
             let ll_p_xz = {
                 // Compute the sample log-likelihood.
-                (ln_gamma(alpha) - &n_z.mapv(ln_gamma).sum())     //.
-                + (ln_gamma(alpha) - &n_xz.mapv(ln_gamma).sum())
+                (ln_gamma(alpha) - n_z.mapv(ln_gamma).sum())     //.
+                + (ln_gamma(alpha) - n_xz.mapv(ln_gamma).sum())
             };
             // Return the total log-likelihood.
             ll_q_xz + ll_p_xz

--- a/causal-hub/src/estimators/parameters/bayesian.rs
+++ b/causal-hub/src/estimators/parameters/bayesian.rs
@@ -216,10 +216,7 @@ macro_for!($type in [CatTrj, CatWtdTrj, CatTrjs, CatWtdTrjs] {
 macro_for!($type in [CatTrjs, CatWtdTrjs] {
 
     impl ParCPDEstimator<CatCIM> for BE<'_, $type, (usize, f64)> {
-        // (conditional counts, conditional time spent, sample size)
-        type SS = (Array3<f64>, Array2<f64>, f64);
-
-        fn par_fit_transform(&self, x: usize, z: &[usize]) -> (Self::SS, CatCIM) {
+        fn par_fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
             // Get (states, prior).
             let (states, prior) = (self.dataset.states(), *self.prior());
             // Compute sufficient statistics in parallel.

--- a/causal-hub/src/estimators/parameters/expectation_maximization.rs
+++ b/causal-hub/src/estimators/parameters/expectation_maximization.rs
@@ -23,7 +23,7 @@ where
 pub type EM<'a, M, E, EStep, E2M, MStep, Stop> =
     ExpectationMaximization<'a, M, E, EStep, E2M, MStep, Stop>;
 
-impl<'a, M, E, EStep, E2M, MStep, Stop> ExpectationMaximization<'a, M, E, EStep, E2M, MStep, Stop>
+impl<'a, M, E, EStep, E2M, MStep, Stop> EM<'a, M, E, EStep, E2M, MStep, Stop>
 where
     M: Clone,
     EStep: Fn(&M, &E) -> E2M,

--- a/causal-hub/src/estimators/parameters/maximum_likelihood.rs
+++ b/causal-hub/src/estimators/parameters/maximum_likelihood.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     datasets::{CatData, CatTrj, CatTrjs, CatWtdTrj, CatWtdTrjs, Dataset},
     distributions::{CPD, CatCIM, CatCPD},
-    types::{FxIndexMap, FxIndexSet},
+    types::{Labels, States},
 };
 
 /// A struct representing a maximum likelihood estimator.
@@ -96,8 +96,8 @@ impl MLE<'_, CatTrj> {
         n_xz: Array3<f64>,
         t_xz: Array2<f64>,
         n: f64,
-        labels: &FxIndexSet<String>,
-        states: &FxIndexMap<String, FxIndexSet<String>>,
+        labels: &Labels,
+        states: &States,
     ) -> ((Array3<f64>, Array2<f64>, f64), CatCIM) {
         // Assert the conditional times counts are not zero.
         assert!(

--- a/causal-hub/src/estimators/parameters/maximum_likelihood.rs
+++ b/causal-hub/src/estimators/parameters/maximum_likelihood.rs
@@ -217,10 +217,7 @@ macro_for!($type in [CatTrj, CatWtdTrj, CatTrjs, CatWtdTrjs] {
 macro_for!($type in [CatTrjs, CatWtdTrjs] {
 
     impl ParCPDEstimator<CatCIM> for MLE<'_, $type> {
-        // (conditional counts, conditional time spent, sample size)
-        type SS = (Array3<f64>, Array2<f64>, f64);
-
-        fn par_fit_transform(&self, x: usize, z: &[usize]) -> (Self::SS, CatCIM) {
+        fn par_fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
             // Get labels and states.
             let (labels, states) = (self.dataset.labels(), self.dataset.states());
 

--- a/causal-hub/src/estimators/parameters/maximum_likelihood.rs
+++ b/causal-hub/src/estimators/parameters/maximum_likelihood.rs
@@ -38,6 +38,11 @@ impl<'a, D> MaximumLikelihoodEstimator<'a, D> {
 }
 
 impl CPDEstimator<CatCPD> for MLE<'_, CatData> {
+    #[inline]
+    fn labels(&self) -> &Labels {
+        self.dataset.labels()
+    }
+
     fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCPD as CPD>::SS, CatCPD) {
         // Get states and cardinality.
         let states = self.dataset.states();
@@ -187,6 +192,10 @@ impl MLE<'_, CatTrj> {
 macro_for!($type in [CatTrj, CatWtdTrj, CatTrjs, CatWtdTrjs] {
 
     impl CPDEstimator<CatCIM> for MLE<'_, $type> {
+        #[inline]
+        fn labels(&self) -> &Labels {
+            self.dataset.labels()
+        }
 
         fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
             // Get labels and states.

--- a/causal-hub/src/estimators/parameters/mod.rs
+++ b/causal-hub/src/estimators/parameters/mod.rs
@@ -18,12 +18,21 @@ use crate::{
     distributions::CPD,
     graphs::{DiGraph, Graph},
     models::{BN, CTBN},
+    types::Labels,
 };
 
 /// A trait for sufficient statistics estimators.
 pub trait ConditionalSufficientStatisticsEstimator {
     /// The type of sufficient statistics.
     type Output;
+
+    /// Returns a reference to the labels of the dataset.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the labels.
+    ///
+    fn labels(&self) -> &Labels;
 
     /// Fits the estimator to the dataset and returns the conditional sufficient statistics.
     ///
@@ -69,6 +78,14 @@ pub trait ConditionalProbabilityDistributionEstimator<P>
 where
     P: CPD,
 {
+    /// Returns a reference to the labels of the dataset.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the labels.
+    ///
+    fn labels(&self) -> &Labels;
+
     /// Fits the estimator to the dataset and returns a CPD.
     ///
     /// # Arguments

--- a/causal-hub/src/estimators/parameters/mod.rs
+++ b/causal-hub/src/estimators/parameters/mod.rs
@@ -121,10 +121,10 @@ where
 pub use ConditionalProbabilityDistributionEstimator as CPDEstimator;
 
 /// A trait for conditional probability distribution estimators in parallel.
-pub trait ParallelConditionalProbabilityDistributionEstimator<P> {
-    /// The type of sufficient statistics.
-    type SS;
-
+pub trait ParallelConditionalProbabilityDistributionEstimator<P>
+where
+    P: CPD,
+{
     /// Fits the estimator to the dataset and returns a CPD in parallel.
     ///
     /// # Arguments
@@ -153,7 +153,7 @@ pub trait ParallelConditionalProbabilityDistributionEstimator<P> {
     ///
     /// The estimated sufficient statistics and CPD.
     ///
-    fn par_fit_transform(&self, x: usize, z: &[usize]) -> (Self::SS, P);
+    fn par_fit_transform(&self, x: usize, z: &[usize]) -> (P::SS, P);
 }
 
 /// A type alias for a parallel conditional probability distribution estimator.
@@ -217,7 +217,7 @@ pub use ParallelBayesianNetworkEstimator as ParBNEstimator;
 impl<T, E> ParBNEstimator<T> for E
 where
     T: BN,
-    T::CPD: Send,
+    T::CPD: CPD + Send,
     E: ParCPDEstimator<T::CPD> + Sync,
 {
     fn par_fit(&self, graph: DiGraph) -> T {
@@ -290,7 +290,7 @@ pub use ParallelContinuousTimeBayesianNetworkEstimator as ParCTBNEstimator;
 impl<T, E> ParCTBNEstimator<T> for E
 where
     T: CTBN,
-    T::CIM: Send,
+    T::CIM: CPD + Send,
     E: ParCPDEstimator<T::CIM> + Sync,
 {
     fn par_fit(&self, graph: DiGraph) -> T {

--- a/causal-hub/src/estimators/parameters/raw.rs
+++ b/causal-hub/src/estimators/parameters/raw.rs
@@ -400,10 +400,7 @@ impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjsEv, CatTrjs
 }
 
 impl<R: Rng + SeedableRng> ParCPDEstimator<CatCIM> for RE<'_, R, CatTrjsEv, CatTrjs> {
-    // (conditional counts, conditional time spent, sample size)
-    type SS = (Array3<f64>, Array2<f64>, f64);
-
-    fn par_fit_transform(&self, x: usize, z: &[usize]) -> (Self::SS, CatCIM) {
+    fn par_fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
         // Estimate the CIM with a uniform prior.
         BE::new(self.dataset.as_ref().unwrap(), (1, 1.)).par_fit_transform(x, z)
     }

--- a/causal-hub/src/estimators/parameters/raw.rs
+++ b/causal-hub/src/estimators/parameters/raw.rs
@@ -28,7 +28,7 @@ pub struct RawEstimator<'a, R, E, D> {
 }
 
 /// A type alias for a raw estimator.
-pub type RE<'a, R, E, D> = RawEstimator<'a, R, E, D>;
+pub type RAWE<'a, R, E, D> = RawEstimator<'a, R, E, D>;
 
 impl<R, E, D> Deref for RawEstimator<'_, R, E, D> {
     type Target = D;
@@ -38,7 +38,7 @@ impl<R, E, D> Deref for RawEstimator<'_, R, E, D> {
     }
 }
 
-impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjEv, CatTrj> {
+impl<'a, R: Rng + SeedableRng> RAWE<'a, R, CatTrjEv, CatTrj> {
     /// Constructs a new raw estimator from the evidence.
     ///
     /// # Arguments
@@ -47,7 +47,7 @@ impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjEv, CatTrj> {
     ///
     /// # Returns
     ///
-    /// A new `RE` instance.
+    /// A new `RAWE` instance.
     ///
     pub fn par_new(rng: &'a mut R, evidence: &'a CatTrjEv) -> Self {
         // Initialize the estimator.
@@ -337,7 +337,7 @@ impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjEv, CatTrj> {
     }
 }
 
-impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjsEv, CatTrjs> {
+impl<'a, R: Rng + SeedableRng> RAWE<'a, R, CatTrjsEv, CatTrjs> {
     /// Constructs a new raw estimator from the evidence.
     ///
     /// # Arguments
@@ -346,7 +346,7 @@ impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjsEv, CatTrjs> {
     ///
     /// # Returns
     ///
-    /// A new `RE` instance.
+    /// A new `RAWE` instance.
     ///
     pub fn par_new(rng: &'a mut R, evidence: &'a CatTrjsEv) -> Self {
         // Sample seed for parallel sampling.
@@ -362,7 +362,7 @@ impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjsEv, CatTrjs> {
                     // Create a new random number generator with the seed.
                     let mut rng = R::seed_from_u64(seed);
                     // Fill the evidence with the raw estimator.
-                    RE::<'_, R, CatTrjEv, CatTrj>::par_new(&mut rng, e)
+                    RAWE::<'_, R, CatTrjEv, CatTrj>::par_new(&mut rng, e)
                         .dataset
                         .unwrap()
                 })
@@ -377,7 +377,7 @@ impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjsEv, CatTrjs> {
     }
 }
 
-impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjEv, CatTrj> {
+impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RAWE<'_, R, CatTrjEv, CatTrj> {
     fn labels(&self) -> &crate::types::Labels {
         self.dataset.as_ref().unwrap().labels()
     }
@@ -388,7 +388,7 @@ impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjEv, CatTrj> 
     }
 }
 
-impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjsEv, CatTrjs> {
+impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RAWE<'_, R, CatTrjsEv, CatTrjs> {
     fn labels(&self) -> &crate::types::Labels {
         self.dataset.as_ref().unwrap().labels()
     }
@@ -399,7 +399,7 @@ impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjsEv, CatTrjs
     }
 }
 
-impl<R: Rng + SeedableRng> ParCPDEstimator<CatCIM> for RE<'_, R, CatTrjsEv, CatTrjs> {
+impl<R: Rng + SeedableRng> ParCPDEstimator<CatCIM> for RAWE<'_, R, CatTrjsEv, CatTrjs> {
     fn par_fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
         // Estimate the CIM with a uniform prior.
         BE::new(self.dataset.as_ref().unwrap(), (1, 1.)).par_fit_transform(x, z)

--- a/causal-hub/src/estimators/parameters/raw.rs
+++ b/causal-hub/src/estimators/parameters/raw.rs
@@ -378,6 +378,10 @@ impl<'a, R: Rng + SeedableRng> RE<'a, R, CatTrjsEv, CatTrjs> {
 }
 
 impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjEv, CatTrj> {
+    fn labels(&self) -> &crate::types::Labels {
+        self.dataset.as_ref().unwrap().labels()
+    }
+
     fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
         // Estimate the CIM with a uniform prior.
         BE::new(self.dataset.as_ref().unwrap(), (1, 1.)).fit_transform(x, z)
@@ -385,6 +389,10 @@ impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjEv, CatTrj> 
 }
 
 impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RE<'_, R, CatTrjsEv, CatTrjs> {
+    fn labels(&self) -> &crate::types::Labels {
+        self.dataset.as_ref().unwrap().labels()
+    }
+
     fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
         // Estimate the CIM with a uniform prior.
         BE::new(self.dataset.as_ref().unwrap(), (1, 1.)).fit_transform(x, z)

--- a/causal-hub/src/estimators/parameters/raw.rs
+++ b/causal-hub/src/estimators/parameters/raw.rs
@@ -10,7 +10,7 @@ use super::{BE, CPDEstimator, ParCPDEstimator};
 use crate::{
     datasets::{CatTrj, CatTrjEv, CatTrjEvT, CatTrjs, CatTrjsEv, Dataset},
     distributions::{CPD, CatCIM},
-    types::FxIndexSet,
+    types::{FxIndexSet, Labels},
 };
 
 // TODO: This must be refactored to be stateless.
@@ -378,8 +378,8 @@ impl<'a, R: Rng + SeedableRng> RAWE<'a, R, CatTrjsEv, CatTrjs> {
 }
 
 impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RAWE<'_, R, CatTrjEv, CatTrj> {
-    fn labels(&self) -> &crate::types::Labels {
-        self.dataset.as_ref().unwrap().labels()
+    fn labels(&self) -> &Labels {
+        self.evidence.labels()
     }
 
     fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {
@@ -389,8 +389,8 @@ impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RAWE<'_, R, CatTrjEv, CatTrj
 }
 
 impl<R: Rng + SeedableRng> CPDEstimator<CatCIM> for RAWE<'_, R, CatTrjsEv, CatTrjs> {
-    fn labels(&self) -> &crate::types::Labels {
-        self.dataset.as_ref().unwrap().labels()
+    fn labels(&self) -> &Labels {
+        self.evidence.labels()
     }
 
     fn fit_transform(&self, x: usize, z: &[usize]) -> (<CatCIM as CPD>::SS, CatCIM) {

--- a/causal-hub/src/estimators/parameters/sufficient_statistics.rs
+++ b/causal-hub/src/estimators/parameters/sufficient_statistics.rs
@@ -7,7 +7,7 @@ use super::{CSSEstimator, ParCSSEstimator};
 use crate::{
     datasets::{CatData, CatTrj, CatTrjs, CatWtdTrj, CatWtdTrjs, Dataset},
     distributions::{CPD, CatCIM, CatCPD},
-    types::FxIndexSet,
+    types::{FxIndexSet, Labels},
     utils::RMI,
 };
 
@@ -35,6 +35,11 @@ pub type SSE<'a, D> = SufficientStatisticsEstimator<'a, D>;
 
 impl CSSEstimator for SSE<'_, CatData> {
     type Output = <CatCPD as CPD>::SS;
+
+    #[inline]
+    fn labels(&self) -> &Labels {
+        self.dataset.labels()
+    }
 
     fn fit(&self, x: usize, z: &[usize]) -> Self::Output {
         // Concat the variables to fit.
@@ -87,6 +92,11 @@ impl CSSEstimator for SSE<'_, CatData> {
 impl CSSEstimator for SSE<'_, CatTrj> {
     type Output = <CatCIM as CPD>::SS;
 
+    #[inline]
+    fn labels(&self) -> &Labels {
+        self.dataset.labels()
+    }
+
     fn fit(&self, x: usize, z: &[usize]) -> Self::Output {
         // Get the cardinality of the trajectory.
         let cards = self.dataset.cardinality();
@@ -133,6 +143,11 @@ impl CSSEstimator for SSE<'_, CatTrj> {
 impl CSSEstimator for SSE<'_, CatWtdTrj> {
     type Output = <CatCIM as CPD>::SS;
 
+    #[inline]
+    fn labels(&self) -> &Labels {
+        self.dataset.labels()
+    }
+
     fn fit(&self, x: usize, z: &[usize]) -> Self::Output {
         // Get the weight of the trajectory.
         let w = self.dataset.weight();
@@ -148,6 +163,11 @@ macro_for!($type in [CatTrjs, CatWtdTrjs] {
 
     impl CSSEstimator for SSE<'_, $type> {
         type Output = <CatCIM as CPD>::SS;
+
+        #[inline]
+        fn labels(&self) -> &Labels {
+            self.dataset.labels()
+        }
 
         fn fit(&self, x: usize, z: &[usize]) -> Self::Output {
             // Get the cardinality of the trajectory.

--- a/causal-hub/src/estimators/structures/continuous_time_hill_climbing.rs
+++ b/causal-hub/src/estimators/structures/continuous_time_hill_climbing.rs
@@ -165,7 +165,6 @@ where
                         // Get the vertices that are not in the current parent set.
                         self.initial_graph
                             .vertices()
-                            .into_iter()
                             .filter_map(move |j| {
                                 if i != j {
                                     // If the vertex is not in the current parent set ...
@@ -263,7 +262,6 @@ where
                             // Get the vertices that are not in the current parent set.
                             self.initial_graph
                                 .vertices()
-                                .into_iter()
                                 .filter_map(move |j| {
                                     if i != j {
                                         // If the vertex is not in the current parent set ...

--- a/causal-hub/src/estimators/structures/continuous_time_hill_climbing.rs
+++ b/causal-hub/src/estimators/structures/continuous_time_hill_climbing.rs
@@ -5,10 +5,19 @@ use crate::{
     distributions::{CPD, CatCIM},
     estimators::CPDEstimator,
     graphs::{DiGraph, Graph},
+    types::Labels,
 };
 
 /// A trait for scoring criteria used in score-based structure learning.
 pub trait ScoringCriterion {
+    /// Returns a reference to the labels of the dataset.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the labels.
+    ///
+    fn labels(&self) -> &Labels;
+
     /// Computes the score for a given variable and its conditioning set.
     ///
     /// # Arguments
@@ -56,6 +65,11 @@ where
     E: CPDEstimator<CatCIM>,
 {
     #[inline]
+    fn labels(&self) -> &Labels {
+        self.estimator.labels()
+    }
+
+    #[inline]
     fn call(&self, x: usize, z: &[usize]) -> f64 {
         // Compute the intensity matrices for the sets.
         let q_xz = self.estimator.fit(x, &z);
@@ -100,8 +114,17 @@ where
     /// A new `ContinuousTimeHillClimbing` instance.
     ///
     #[inline]
-    pub const fn new(initial_graph: &'a DiGraph, score: &'a S) -> Self {
-        // FIXME: Check initial graph and score have the same labels.
+    pub fn new(initial_graph: &'a DiGraph, score: &'a S) -> Self {
+        // Assert labels of the initial graph and the estimator are the same.
+        assert_eq!(
+            initial_graph.labels(),
+            score.labels(),
+            "Labels of initial graph and estimator must be the same: \n\
+            \t expected:    {:?}, \n\
+            \t found:       {:?}.",
+            initial_graph.labels(),
+            score.labels()
+        );
 
         Self {
             initial_graph,

--- a/causal-hub/src/estimators/structures/continuous_time_peter_clark.rs
+++ b/causal-hub/src/estimators/structures/continuous_time_peter_clark.rs
@@ -7,10 +7,19 @@ use crate::{
     distributions::{CPD, CatCIM},
     estimators::CPDEstimator,
     graphs::{DiGraph, Graph},
+    types::Labels,
 };
 
 /// A trait for conditional independence testing.
 pub trait ConditionalIndependenceTest {
+    /// Returns a reference to the labels of the dataset.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the labels.
+    ///
+    fn labels(&self) -> &Labels;
+
     /// Test for conditional independence as X _||_ Y | Z.
     ///
     /// # Arguments
@@ -64,6 +73,11 @@ impl<E> CIT for ChiSquaredTest<'_, E>
 where
     E: CPDEstimator<CatCIM>,
 {
+    #[inline]
+    fn labels(&self) -> &Labels {
+        self.estimator.labels()
+    }
+
     fn call(&self, x: usize, y: usize, z: &[usize]) -> bool {
         // Compute the extended separation set.
         let mut s = z.to_vec();
@@ -155,6 +169,11 @@ impl<E> CIT for FTest<'_, E>
 where
     E: CPDEstimator<CatCIM>,
 {
+    #[inline]
+    fn labels(&self) -> &Labels {
+        self.estimator.labels()
+    }
+
     fn call(&self, x: usize, y: usize, z: &[usize]) -> bool {
         // Compute the alpha range.
         let alpha = (self.alpha / 2.)..=(1. - self.alpha / 2.);
@@ -231,8 +250,27 @@ where
     /// A new `ContinuousTimePeterClark` instance.
     ///
     #[inline]
-    pub const fn new(initial_graph: &'a DiGraph, null_time: &'a T, null_state: &'a S) -> Self {
-        // FIXME: Check initial graph and tests have the same labels.
+    pub fn new(initial_graph: &'a DiGraph, null_time: &'a T, null_state: &'a S) -> Self {
+        // Assert labels of the initial graph and the estimator are the same.
+        assert_eq!(
+            initial_graph.labels(),
+            null_time.labels(),
+            "Labels of initial graph and estimator must be the same: \n\
+            \t expected:    {:?}, \n\
+            \t found:       {:?}.",
+            initial_graph.labels(),
+            null_time.labels()
+        );
+        // Assert labels of the initial graph and the estimator are the same.
+        assert_eq!(
+            initial_graph.labels(),
+            null_state.labels(),
+            "Labels of initial graph and estimator must be the same: \n\
+            \t expected:    {:?}, \n\
+            \t found:       {:?}.",
+            initial_graph.labels(),
+            null_state.labels()
+        );
 
         Self {
             initial_graph,

--- a/causal-hub/src/estimators/structures/mod.rs
+++ b/causal-hub/src/estimators/structures/mod.rs
@@ -3,3 +3,6 @@ pub use continuous_time_hill_climbing::*;
 
 mod continuous_time_peter_clark;
 pub use continuous_time_peter_clark::*;
+
+mod prior_knowledge;
+pub use prior_knowledge::*;

--- a/causal-hub/src/estimators/structures/prior_knowledge.rs
+++ b/causal-hub/src/estimators/structures/prior_knowledge.rs
@@ -1,0 +1,249 @@
+use std::fmt::Display;
+
+use itertools::Itertools;
+use ndarray::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::types::Labels;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[repr(C)]
+enum PriorKnowledgeState {
+    Unknown,
+    Forbidden,
+    Required,
+}
+
+type PKS = PriorKnowledgeState;
+
+impl PKS {
+    #[inline]
+    pub const fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+
+    #[inline]
+    pub const fn is_forbidden(&self) -> bool {
+        matches!(self, Self::Forbidden)
+    }
+
+    #[inline]
+    pub const fn is_required(&self) -> bool {
+        matches!(self, Self::Required)
+    }
+}
+
+impl Display for PKS {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown => write!(f, "Unknown"),
+            Self::Forbidden => write!(f, "Forbidden"),
+            Self::Required => write!(f, "Required"),
+        }
+    }
+}
+
+/// A structure representing prior knowledge for structure learning.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PriorKnowledge {
+    labels: Labels,
+    adjacency_matrix: Array2<PKS>,
+}
+
+/// A type alias for prior knowledge.
+pub type PK = PriorKnowledge;
+
+impl PriorKnowledge {
+    /// Creates a new instance of prior knowledge.
+    ///
+    /// # Arguments
+    ///
+    /// * `labels` - The labels of the vertices.
+    /// * `forbidden` - An iterator over forbidden edges.
+    /// * `required` - An iterator over required edges.
+    /// * `temporal_order` - An iterator over tiers of vertices, where each tier is an iterator of vertex indices.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of prior knowledge.
+    ///
+    pub fn new<I, J, K, L>(labels: Labels, forbidden: I, required: J, temporal_order: K) -> Self
+    where
+        I: IntoIterator<Item = (usize, usize)>,
+        J: IntoIterator<Item = (usize, usize)>,
+        K: IntoIterator<Item = L>,
+        L: IntoIterator<Item = usize>,
+    {
+        // Get the number of labels.
+        let n = labels.len();
+        // Initialize an adjacency matrix with `Unknown` state.
+        let mut adjacency_matrix = Array::from_elem((n, n), PKS::Unknown);
+
+        // Set the forbidden edges to `Forbidden`.
+        forbidden.into_iter().for_each(|(i, j)| {
+            // Set the edge to `Forbidden`.
+            adjacency_matrix[[i, j]] = PKS::Forbidden;
+        });
+
+        // Set the required edges to `Required`.
+        required.into_iter().for_each(|(i, j)| {
+            // Assert that the edge is set to unknown.
+            assert!(
+                adjacency_matrix[[i, j]].is_unknown(),
+                "Edge ({i}, {j}) is already set to a non-unknown state: \n\
+                \t expected:    ({i}, {j}) set to 'Unknown', \n\",
+                \t found:       ({i}, {j}) set to '{}'.",
+                adjacency_matrix[[i, j]]
+            );
+            // Set the edge to `Required`.
+            adjacency_matrix[[i, j]] = PKS::Required;
+        });
+
+        // Collect the tiered edges.
+        let temporal_order: Vec<Vec<_>> = temporal_order
+            .into_iter()
+            .map(|tier| tier.into_iter().collect())
+            .collect();
+        // Edges from a vertex in a higher tier to a vertex in a lower tier are forbidden.
+        temporal_order.iter().enumerate().for_each(|(t, tier)| {
+            // Get the vertices in previous tiers.
+            let previous_tiers = temporal_order[..t].iter().flatten();
+            // For each vertex in the current tier, set edges to previous tiers as forbidden.
+            tier.iter()
+                .cartesian_product(previous_tiers)
+                .for_each(|(&i, &j)| {
+                    // Assert that the edge is not required.
+                    assert!(
+                        !adjacency_matrix[[i, j]].is_required(),
+                        "Edge ({i}, {j}) is already set to a 'Required' state: \n\
+                        \t expected:    ({i}, {j}) set to 'Unknown' or 'Forbidden', \n\",
+                        \t found:       ({i}, {j}) set to '{}'.",
+                        adjacency_matrix[[i, j]]
+                    );
+                    // Set the edge to `Forbidden`.
+                    adjacency_matrix[[i, j]] = PKS::Forbidden;
+                });
+        });
+
+        Self {
+            labels,
+            adjacency_matrix,
+        }
+    }
+
+    /// Returns a reference to the labels of the prior knowledge.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the labels.
+    ///
+    #[inline]
+    pub const fn labels(&self) -> &Labels {
+        &self.labels
+    }
+
+    /// Checks if an edge is unknown.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The index of the first vertex.
+    /// * `y` - The index of the second vertex.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the edge is unknown, `false` otherwise.
+    ///
+    #[inline]
+    pub fn is_unknown(&self, x: usize, y: usize) -> bool {
+        self.adjacency_matrix[[x, y]].is_unknown()
+    }
+
+    /// Returns the unknown edges.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tuples representing the indices of the unknown edges.
+    ///
+    pub fn unknown_edges(&self) -> Vec<(usize, usize)> {
+        self.adjacency_matrix
+            .indexed_iter()
+            .filter_map(|((i, j), &state)| {
+                if state.is_unknown() {
+                    Some((i, j))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Checks if an edge is forbidden.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The index of the first vertex.
+    /// * `y` - The index of the second vertex.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the edge is forbidden, `false` otherwise.
+    ///
+    #[inline]
+    pub fn is_forbidden(&self, x: usize, y: usize) -> bool {
+        self.adjacency_matrix[[x, y]].is_forbidden()
+    }
+
+    /// Returns the forbidden edges.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tuples representing the indices of the forbidden edges.
+    ///
+    pub fn forbidden_edges(&self) -> Vec<(usize, usize)> {
+        self.adjacency_matrix
+            .indexed_iter()
+            .filter_map(|((i, j), &state)| {
+                if state.is_forbidden() {
+                    Some((i, j))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Checks if an edge is required.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The index of the first vertex.
+    /// * `y` - The index of the second vertex.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the edge is required, `false` otherwise.
+    ///
+    #[inline]
+    pub fn is_required(&self, x: usize, y: usize) -> bool {
+        self.adjacency_matrix[[x, y]].is_required()
+    }
+
+    /// Returns the required edges.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tuples representing the indices of the required edges.
+    ///
+    pub fn required_edges(&self) -> Vec<(usize, usize)> {
+        self.adjacency_matrix
+            .indexed_iter()
+            .filter_map(|((i, j), &state)| {
+                if state.is_required() {
+                    Some((i, j))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}

--- a/causal-hub/src/estimators/structures/prior_knowledge.rs
+++ b/causal-hub/src/estimators/structures/prior_knowledge.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use ndarray::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::types::Labels;
+use crate::{types::Labels, utils::collect_labels};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[repr(C)]
@@ -67,13 +67,17 @@ impl PriorKnowledge {
     ///
     /// A new instance of prior knowledge.
     ///
-    pub fn new<I, J, K, L>(labels: Labels, forbidden: I, required: J, temporal_order: K) -> Self
+    pub fn new<I, J, K, L, M, N>(labels: I, forbidden: J, required: K, temporal_order: L) -> Self
     where
-        I: IntoIterator<Item = (usize, usize)>,
+        I: IntoIterator<Item = N>,
         J: IntoIterator<Item = (usize, usize)>,
-        K: IntoIterator<Item = L>,
-        L: IntoIterator<Item = usize>,
+        K: IntoIterator<Item = (usize, usize)>,
+        L: IntoIterator<Item = M>,
+        M: IntoIterator<Item = usize>,
+        N: AsRef<str>,
     {
+        // Collect the labels.
+        let labels = collect_labels(labels);
         // Get the number of labels.
         let n = labels.len();
         // Initialize an adjacency matrix with `Unknown` state.

--- a/causal-hub/src/graphs/directed.rs
+++ b/causal-hub/src/graphs/directed.rs
@@ -82,7 +82,6 @@ impl DiGraph {
 }
 
 impl Graph for DiGraph {
-    type Labels = Labels;
     type Vertices = Range<usize>;
     type Edges = Vec<(usize, usize)>;
 
@@ -152,7 +151,7 @@ impl Graph for DiGraph {
         }
     }
 
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         &self.labels
     }
 

--- a/causal-hub/src/graphs/directed.rs
+++ b/causal-hub/src/graphs/directed.rs
@@ -4,12 +4,12 @@ use ndarray::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::Graph;
-use crate::types::FxIndexSet;
+use crate::types::Labels;
 
 /// A struct representing a directed graph using an adjacency matrix.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DirectedGraph {
-    labels: FxIndexSet<String>,
+    labels: Labels,
     adjacency_matrix: Array2<bool>,
 }
 
@@ -82,7 +82,7 @@ impl DiGraph {
 }
 
 impl Graph for DiGraph {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Vertices = Range<usize>;
     type Edges = Vec<(usize, usize)>;
 
@@ -94,7 +94,7 @@ impl Graph for DiGraph {
         // Initialize labels counter.
         let mut n = 0;
         // Collect the labels.
-        let mut labels: FxIndexSet<_> = labels
+        let mut labels: Labels = labels
             .into_iter()
             .inspect(|_| n += 1)
             .map(|x| x.as_ref().to_owned())
@@ -126,7 +126,7 @@ impl Graph for DiGraph {
         // Initialize labels counter.
         let mut n = 0;
         // Collect the labels.
-        let mut labels: FxIndexSet<_> = labels
+        let mut labels: Labels = labels
             .into_iter()
             .inspect(|_| n += 1)
             .map(|x| x.as_ref().to_owned())

--- a/causal-hub/src/graphs/mod.rs
+++ b/causal-hub/src/graphs/mod.rs
@@ -7,10 +7,10 @@ pub use topological_order::*;
 mod undirected;
 pub use undirected::*;
 
+use crate::types::Labels;
+
 /// A trait for graphs.
 pub trait Graph {
-    /// The type of the labels.
-    type Labels;
     /// The type of the vertices.
     type Vertices: IntoIterator<Item = usize>;
     /// The type of the edges.
@@ -69,7 +69,7 @@ pub trait Graph {
     ///
     /// A reference to the vector of labels.
     ///
-    fn labels(&self) -> &Self::Labels;
+    fn labels(&self) -> &Labels;
 
     /// Return the vertex index for a given label.
     ///

--- a/causal-hub/src/graphs/undirected.rs
+++ b/causal-hub/src/graphs/undirected.rs
@@ -4,12 +4,12 @@ use ndarray::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::Graph;
-use crate::types::FxIndexSet;
+use crate::types::Labels;
 
 /// A struct representing an undirected graph using an adjacency matrix.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UndirectedGraph {
-    labels: FxIndexSet<String>,
+    labels: Labels,
     adjacency_matrix: Array2<bool>,
 }
 
@@ -46,7 +46,7 @@ impl UnGraph {
 }
 
 impl Graph for UnGraph {
-    type Labels = FxIndexSet<String>;
+    type Labels = Labels;
     type Vertices = Range<usize>;
     type Edges = Vec<(usize, usize)>;
 
@@ -58,7 +58,7 @@ impl Graph for UnGraph {
         // Initialize labels counter.
         let mut n = 0;
         // Collect the labels.
-        let mut labels: FxIndexSet<_> = labels
+        let mut labels: Labels = labels
             .into_iter()
             .inspect(|_| n += 1)
             .map(|x| x.as_ref().to_owned())
@@ -90,7 +90,7 @@ impl Graph for UnGraph {
         // Initialize labels counter.
         let mut n = 0;
         // Collect the labels.
-        let mut labels: FxIndexSet<_> = labels
+        let mut labels: Labels = labels
             .into_iter()
             .inspect(|_| n += 1)
             .map(|x| x.as_ref().to_owned())

--- a/causal-hub/src/graphs/undirected.rs
+++ b/causal-hub/src/graphs/undirected.rs
@@ -46,7 +46,6 @@ impl UnGraph {
 }
 
 impl Graph for UnGraph {
-    type Labels = Labels;
     type Vertices = Range<usize>;
     type Edges = Vec<(usize, usize)>;
 
@@ -116,7 +115,7 @@ impl Graph for UnGraph {
         }
     }
 
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         &self.labels
     }
 

--- a/causal-hub/src/io/bif/parser.rs
+++ b/causal-hub/src/io/bif/parser.rs
@@ -7,7 +7,7 @@ use crate::{
     distributions::{CPD, CatCPD},
     graphs::{DiGraph, Graph},
     models::{BN, CatBN},
-    types::{FxIndexMap, FxIndexSet},
+    types::{FxIndexMap, States},
 };
 
 #[derive(Debug)]
@@ -53,7 +53,7 @@ impl BifReader {
             .next()
             .expect("Failed to parse BIF file.");
         // Construct states.
-        let states: FxIndexMap<_, FxIndexSet<_>> = network
+        let states: States = network
             .variables
             .into_iter()
             .map(|v| (v.label, v.states.into_iter().collect()))

--- a/causal-hub/src/io/csv.rs
+++ b/causal-hub/src/io/csv.rs
@@ -5,7 +5,7 @@ use ndarray::prelude::*;
 
 use crate::{
     datasets::CatData,
-    types::{FxIndexMap, FxIndexSet},
+    types::{Labels, States},
 };
 
 /// A trait for reading CSV files.
@@ -52,7 +52,7 @@ impl FromCsvReader for CatData {
         // Initialize the counter.
         let mut n = 0;
         // Read the headers.
-        let labels: FxIndexSet<_> = reader
+        let labels: Labels = reader
             .headers()
             .expect("Failed to read the headers.")
             .into_iter()
@@ -63,7 +63,7 @@ impl FromCsvReader for CatData {
         assert_eq!(labels.len(), n, "Header labels must be unique.");
 
         // Get the states of the variables.
-        let mut states: FxIndexMap<_, FxIndexSet<String>> = labels
+        let mut states: States = labels
             .into_iter()
             .map(|x| (x, Default::default()))
             .collect();

--- a/causal-hub/src/models/bayesian_network/categorical.rs
+++ b/causal-hub/src/models/bayesian_network/categorical.rs
@@ -7,7 +7,7 @@ use crate::{
     datasets::CatData,
     distributions::{CPD, CatCPD},
     graphs::{DiGraph, Graph, TopologicalOrder},
-    types::{FxIndexMap, States},
+    types::{FxIndexMap, Labels, States},
 };
 
 /// A categorical Bayesian network (BN).
@@ -85,7 +85,6 @@ impl RelativeEq for CatBN {
 }
 
 impl BN for CatBN {
-    type Labels = <DiGraph as Graph>::Labels;
     type CPD = CatCPD;
     type Sample = Array1<u8>;
     type Samples = CatData;
@@ -159,7 +158,7 @@ impl BN for CatBN {
     }
 
     #[inline]
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         self.graph.labels()
     }
 

--- a/causal-hub/src/models/bayesian_network/categorical.rs
+++ b/causal-hub/src/models/bayesian_network/categorical.rs
@@ -7,14 +7,14 @@ use crate::{
     datasets::CatData,
     distributions::{CPD, CatCPD},
     graphs::{DiGraph, Graph, TopologicalOrder},
-    types::{FxIndexMap, FxIndexSet},
+    types::{FxIndexMap, States},
 };
 
 /// A categorical Bayesian network (BN).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CategoricalBayesianNetwork {
     /// The states of the variables.
-    states: FxIndexMap<String, FxIndexSet<String>>,
+    states: States,
     /// The underlying graph.
     graph: DiGraph,
     /// The conditional probability distributions.
@@ -34,7 +34,7 @@ impl CatBN {
     /// A reference to the states of the variables.
     ///
     #[inline]
-    pub const fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn states(&self) -> &States {
         &self.states
     }
 }
@@ -109,7 +109,7 @@ impl BN for CatBN {
         );
 
         // Allocate the states of the variables.
-        let mut states: FxIndexMap<String, FxIndexSet<String>> = FxIndexMap::default();
+        let mut states: States = Default::default();
         // Insert the states of the variables into the map to check if they are the same.
         for cpd in cpds.values() {
             std::iter::once((cpd.label(), cpd.states()))

--- a/causal-hub/src/models/bayesian_network/mod.rs
+++ b/causal-hub/src/models/bayesian_network/mod.rs
@@ -1,12 +1,13 @@
 mod categorical;
 pub use categorical::*;
 
-use crate::{graphs::DiGraph, types::FxIndexMap};
+use crate::{
+    graphs::DiGraph,
+    types::{FxIndexMap, Labels},
+};
 
 /// A trait for Bayesian networks.
 pub trait BayesianNetwork {
-    /// The type of the labels.
-    type Labels;
     /// The type of the CPD.
     type CPD;
     /// The type of the sample.
@@ -35,7 +36,7 @@ pub trait BayesianNetwork {
     ///
     /// A reference to the labels.
     ///
-    fn labels(&self) -> &Self::Labels;
+    fn labels(&self) -> &Labels;
 
     /// Returns the underlying graph.
     ///

--- a/causal-hub/src/models/continuous_time_bayesian_network/categorical.rs
+++ b/causal-hub/src/models/continuous_time_bayesian_network/categorical.rs
@@ -8,7 +8,7 @@ use crate::{
     distributions::{CPD, CatCIM, CatCPD},
     graphs::{DiGraph, Graph},
     models::{BN, CatBN},
-    types::{FxIndexMap, FxIndexSet},
+    types::{FxIndexMap, States},
 };
 
 /// A categorical continuous time Bayesian network (CTBN).
@@ -33,7 +33,7 @@ impl CatCTBN {
     /// A reference to the states of the variables.
     ///
     #[inline]
-    pub const fn states(&self) -> &FxIndexMap<String, FxIndexSet<String>> {
+    pub const fn states(&self) -> &States {
         self.initial_distribution.states()
     }
 }

--- a/causal-hub/src/models/continuous_time_bayesian_network/categorical.rs
+++ b/causal-hub/src/models/continuous_time_bayesian_network/categorical.rs
@@ -8,7 +8,7 @@ use crate::{
     distributions::{CPD, CatCIM, CatCPD},
     graphs::{DiGraph, Graph},
     models::{BN, CatBN},
-    types::{FxIndexMap, States},
+    types::{FxIndexMap, Labels, States},
 };
 
 /// A categorical continuous time Bayesian network (CTBN).
@@ -82,7 +82,6 @@ impl RelativeEq for CatCTBN {
 }
 
 impl CTBN for CatCTBN {
-    type Labels = <DiGraph as Graph>::Labels;
     type CIM = CatCIM;
     type InitialDistribution = CatBN;
     type Event = (f64, Array1<u8>);
@@ -148,7 +147,7 @@ impl CTBN for CatCTBN {
         }
     }
 
-    fn labels(&self) -> &Self::Labels {
+    fn labels(&self) -> &Labels {
         self.graph.labels()
     }
 

--- a/causal-hub/src/models/continuous_time_bayesian_network/mod.rs
+++ b/causal-hub/src/models/continuous_time_bayesian_network/mod.rs
@@ -1,12 +1,13 @@
 mod categorical;
 pub use categorical::*;
 
-use crate::{graphs::DiGraph, types::FxIndexMap};
+use crate::{
+    graphs::DiGraph,
+    types::{FxIndexMap, Labels},
+};
 
 /// A trait for continuous time Bayesian networks (CTBNs).
 pub trait ContinuousTimeBayesianNetwork {
-    /// The type of the labels.
-    type Labels;
     /// The type of the CIM.
     type CIM;
     /// The type of the initial distribution.
@@ -44,7 +45,7 @@ pub trait ContinuousTimeBayesianNetwork {
     ///
     /// A reference to the labels.
     ///
-    fn labels(&self) -> &Self::Labels;
+    fn labels(&self) -> &Labels;
 
     /// Returns the underlying graph.
     ///

--- a/causal-hub/src/types/cache.rs
+++ b/causal-hub/src/types/cache.rs
@@ -40,6 +40,10 @@ where
     P: CPD + Clone,
     P::SS: Clone,
 {
+    fn labels(&self) -> &super::Labels {
+        self.call.labels()
+    }
+
     fn fit_transform(&self, x: usize, z: &[usize]) -> (P::SS, P) {
         // Get the key.
         let key = (x, z.to_vec());

--- a/causal-hub/src/types/states.rs
+++ b/causal-hub/src/types/states.rs
@@ -5,3 +5,7 @@ use indexmap::{IndexMap, IndexSet};
 pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 /// A type alias for a hash set with a fast hash function.
 pub type FxIndexSet<T> = IndexSet<T, FxBuildHasher>;
+/// A type alias for a set of labels, which are strings.
+pub type Labels = FxIndexSet<String>;
+/// A type alias for a hash map of states, where keys are variable names and values are sets of states.
+pub type States = FxIndexMap<String, FxIndexSet<String>>;

--- a/causal-hub/src/utils/transform_states.rs
+++ b/causal-hub/src/utils/transform_states.rs
@@ -1,4 +1,32 @@
-use crate::types::{FxIndexSet, States};
+use crate::types::{FxIndexSet, Labels, States};
+
+/// Utility function to collect labels from an iterator.
+pub fn collect_labels<I, J>(labels: I) -> Labels
+where
+    I: IntoIterator<Item = J>,
+    J: AsRef<str>,
+{
+    // Initialize labels counter.
+    let mut n = 0;
+    // Convert the variable labels to a set of strings.
+    let labels: Labels = labels
+        .into_iter()
+        .inspect(|_| n += 1)
+        .map(|x| x.as_ref().to_owned())
+        .collect();
+    // Assert unique labels.
+    assert_eq!(
+        labels.len(),
+        n,
+        "Variable labels must be unique: \n\
+        \t expected:    |labels.unique()| == {} , \n\
+        \t found:       |labels.unique()| == {} .",
+        n,
+        labels.len(),
+    );
+
+    labels
+}
 
 /// Utility function to collect states from an iterator.
 pub fn collect_states<I, J, K, V>(states: I) -> States

--- a/causal-hub/src/utils/transform_states.rs
+++ b/causal-hub/src/utils/transform_states.rs
@@ -1,7 +1,7 @@
-use crate::types::{FxIndexMap, FxIndexSet};
+use crate::types::{FxIndexSet, States};
 
 /// Utility function to collect states from an iterator.
-pub fn collect_states<I, J, K, V>(states: I) -> FxIndexMap<String, FxIndexSet<String>>
+pub fn collect_states<I, J, K, V>(states: I) -> States
 where
     I: IntoIterator<Item = (K, J)>,
     J: IntoIterator<Item = V>,
@@ -11,7 +11,7 @@ where
     // Initialize variables counter.
     let mut n = 0;
     // Get the states of the variables.
-    let states: FxIndexMap<_, _> = states
+    let states: States = states
         .into_iter()
         .inspect(|_| n += 1)
         .map(|(label, states)| {
@@ -27,25 +27,36 @@ where
                 .map(|x| x.as_ref().to_owned())
                 .collect();
             // Assert unique states.
-            assert_eq!(states.len(), n, "Variables states must be unique.");
+            assert_eq!(
+                states.len(),
+                n,
+                "Variable states must be unique: \n\
+                \t expected:    |states['{label}'].unique()| == {} , \n\
+                \t found:       |states['{label}'].unique()| == {} .",
+                n,
+                states.len(),
+            );
 
             (label, states)
         })
         .collect();
 
     // Assert unique labels.
-    assert_eq!(states.len(), n, "Variables labels must be unique.");
+    assert_eq!(
+        states.len(),
+        n,
+        "Variable labels must be unique: \n\
+        \t expected:    |labels.unique()| == {} , \n\
+        \t found:       |labels.unique()| == {} .",
+        n,
+        states.len(),
+    );
 
     states
 }
 
 /// Utility function to sort states and labels.
-pub fn sort_states(
-    mut states: FxIndexMap<String, FxIndexSet<String>>,
-) -> (
-    FxIndexMap<String, FxIndexSet<String>>,
-    Vec<(usize, Vec<usize>)>,
-) {
+pub fn sort_states(mut states: States) -> (States, Vec<(usize, Vec<usize>)>) {
     // Get the indices to sort the labels and states labels.
     let mut sorted_indices: Vec<(_, Vec<_>)> = states
         .values()

--- a/causal-hub/tests/datasets/categorical.rs
+++ b/causal-hub/tests/datasets/categorical.rs
@@ -66,6 +66,94 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "Variable states must be unique: \n\t expected:    |states['A'].unique()| == 3 , \n\t found:       |states['A'].unique()| == 2 ."]
+    fn test_new_non_unique_states() {
+        let variables = vec![
+            ("B", vec!["no", "yes"]),
+            ("C", vec!["yes", "no"]),
+            ("A", vec!["no", "yes", "no"]), // 'no' is repeated
+        ];
+        let values = array![
+            [0, 1, 0], //
+            [0, 0, 0], //
+            [1, 0, 0], //
+            [1, 0, 1]
+        ];
+        CatData::new(variables, values);
+    }
+
+    #[test]
+    #[should_panic = "Variable labels must be unique: \n\t expected:    |labels.unique()| == 4 , \n\t found:       |labels.unique()| == 3 ."]
+    fn test_new_non_unique_labels() {
+        let variables = vec![
+            ("B", vec!["no", "yes"]),
+            ("C", vec!["yes", "no"]),
+            ("A", vec!["no", "yes"]),
+            ("A", vec!["maybe"]), // 'A' is repeated
+        ];
+        let values = array![
+            [0, 1, 0, 0], //
+            [0, 0, 0, 1], //
+            [1, 0, 0, 1], //
+            [1, 0, 1, 0]
+        ];
+        CatData::new(variables, values);
+    }
+
+    #[test]
+    #[should_panic = "Variable 'A' should have less than 256 states: \n\t expected:    |states| <  256 , \n\t found:       |states| == 256 ."]
+    fn test_new_too_many_states() {
+        let too_many_states: Vec<_> = (0..256).map(|i| i.to_string()).collect();
+        let too_many_states: Vec<_> = too_many_states.iter().map(|s| s.as_str()).collect();
+        let variables = vec![
+            ("B", vec!["no", "yes"]),
+            ("C", vec!["yes", "no"]),
+            ("A", too_many_states),
+        ];
+        let values = array![
+            [0, 1, 0], //
+            [0, 0, 0], //
+            [1, 0, 0], //
+            [1, 0, 1]
+        ];
+        CatData::new(variables, values);
+    }
+
+    #[test]
+    #[should_panic = "Number of variables must be equal to the number of columns: \n\t expected:    |states| == |values.columns()| , \n\t found:       |states| == 3 and |values.columns()| == 2 ."]
+    fn test_new_wrong_variables_and_columns() {
+        let variables = vec![
+            ("B", vec!["no", "yes"]),
+            ("C", vec!["yes", "no"]),
+            ("A", vec!["no", "yes"]),
+        ];
+        let values = array![
+            [0, 1], //
+            [0, 0], //
+            [1, 0], //
+            [1, 0]
+        ];
+        CatData::new(variables, values);
+    }
+
+    #[test]
+    #[should_panic = "Values of variable 'A' must be less than the number of states: \n\t expected: values[.., 'A'] < |states['A']| , \n\t found:    values[.., 'A'] == 2 and |states['A']| == 2 ."]
+    fn test_new_wrong_values() {
+        let variables = vec![
+            ("B", vec!["no", "yes"]),
+            ("C", vec!["yes", "no"]),
+            ("A", vec!["no", "yes"]),
+        ];
+        let values = array![
+            [0, 1, 2], // 'A' has a value of 2 which is not valid
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 1]
+        ];
+        CatData::new(variables, values);
+    }
+
+    #[test]
     fn test_display() {
         let variables = vec![
             ("B", vec!["no", "yes"]),

--- a/causal-hub/tests/estimators/parameters/expectation_maximization.rs
+++ b/causal-hub/tests/estimators/parameters/expectation_maximization.rs
@@ -7,7 +7,7 @@ mod tests {
         use causal_hub::{
             assets::load_eating,
             datasets::{CatTrjEv, CatTrjs, CatTrjsEv, CatWtdTrjs, Dataset},
-            estimators::{BE, CPDEstimator, EMBuilder, MLE, ParCTBNEstimator, RE},
+            estimators::{BE, CPDEstimator, EMBuilder, MLE, ParCTBNEstimator, RAWE},
             graphs::Graph,
             models::{CTBN, CatCTBN},
             random::RngEv,
@@ -132,7 +132,7 @@ mod tests {
             let evidence = generator.random();
 
             // Initialize a raw estimator for an initial guess.
-            let raw = RE::<'_, _, CatTrjsEv, CatTrjs>::par_new(&mut rng, &evidence);
+            let raw = RAWE::<'_, _, CatTrjsEv, CatTrjs>::par_new(&mut rng, &evidence);
             // Set the initial CIMs.
             let initial_cims: Vec<_> = model
                 .graph()

--- a/causal-hub/tests/estimators/parameters/raw.rs
+++ b/causal-hub/tests/estimators/parameters/raw.rs
@@ -3,7 +3,7 @@ mod tests {
     use causal_hub::{
         assets::load_eating,
         datasets::{CatTrj, CatTrjEv, CatTrjEvT, Dataset},
-        estimators::RE,
+        estimators::RAWE,
     };
     use ndarray::prelude::*;
     use rand::SeedableRng;
@@ -42,7 +42,7 @@ mod tests {
             ],
         );
         // Fill the evidence.
-        let filled_evidence = RE::<'_, _, CatTrjEv, CatTrj>::par_new(&mut rng, &evidence);
+        let filled_evidence = RAWE::<'_, _, CatTrjEv, CatTrj>::par_new(&mut rng, &evidence);
         // Check the filled evidence times.
         assert_eq!(filled_evidence.times(), array![0., 0.1, 0.3, 0.5, 0.6]);
         // Check the filled evidence.
@@ -97,7 +97,7 @@ mod tests {
             ],
         );
         // Fill the evidence.
-        let filled_evidence = RE::<'_, _, CatTrjEv, CatTrj>::par_new(&mut rng, &evidence);
+        let filled_evidence = RAWE::<'_, _, CatTrjEv, CatTrj>::par_new(&mut rng, &evidence);
         // Check the filled evidence times.
         assert_eq!(filled_evidence.times(), array![0., 0.1, 0.3, 0.5, 0.6]);
         // Check the filled evidence.

--- a/causal-hub/tests/estimators/structures/mod.rs
+++ b/causal-hub/tests/estimators/structures/mod.rs
@@ -1,2 +1,3 @@
 mod continuous_time_peter_clark;
 mod structural_expectation_maximization;
+mod prior_knowledge;

--- a/causal-hub/tests/estimators/structures/mod.rs
+++ b/causal-hub/tests/estimators/structures/mod.rs
@@ -1,3 +1,3 @@
 mod continuous_time_peter_clark;
-mod structural_expectation_maximization;
 mod prior_knowledge;
+mod structural_expectation_maximization;

--- a/causal-hub/tests/estimators/structures/prior_knowledge.rs
+++ b/causal-hub/tests/estimators/structures/prior_knowledge.rs
@@ -1,0 +1,27 @@
+#[cfg(test)]
+mod tests {
+    use causal_hub::estimators::PK;
+
+    #[test]
+    fn test_new() {
+        // Initialize a list of labels.
+        let labels = vec!["A", "B", "C"];
+        // Set the forbidden edges.
+        let forbidden = vec![(0, 1), (1, 2)];
+        // Set the required edges.
+        let required = vec![(0, 2)];
+        // Set the temporal order.
+        let temporal_order = vec![vec![0], vec![1, 2]];
+        // Create a new instance of prior knowledge.
+        let pk = PK::new(labels, forbidden, required, temporal_order);
+
+        // Assert a single forbidden edge.
+        assert!(pk.is_forbidden(0, 1));
+        // Assert the forbidden edges.
+        assert_eq!(pk.forbidden_edges(), &[(0, 1), (1, 0), (1, 2), (2, 0)]);
+        // Assert a single required edge.
+        assert!(pk.is_required(0, 2));
+        // Assert the required edges.
+        assert_eq!(pk.required_edges(), &[(0, 2)]);
+    }
+}

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 approx.workspace = true
 causal-hub = { path = "../causal-hub" }
 dry.workspace = true
+log.workspace = true
 numpy = "^0.25"
 paste.workspace = true
 pyo3 = { version = "^0.25", features = ["extension-module", "serde"] }

--- a/python/src/datasets/trajectory/dataset.rs
+++ b/python/src/datasets/trajectory/dataset.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use causal_hub::{
     datasets::{CatTrj, CatTrjs, Dataset},
-    types::{FxIndexMap, FxIndexSet},
+    types::{FxIndexSet, States},
 };
 use numpy::{PyArray1, ndarray::prelude::*, prelude::*};
 use pyo3::{
@@ -93,7 +93,7 @@ impl PyCatTrj {
         assert!(!columns.is_empty(), "The data frame is empty.");
 
         // Construct the states.
-        let states: FxIndexMap<_, _> = with_states
+        let states: States = with_states
             // If `with_states` is provided, convert it to a FxIndexMap.
             .map(|states| {
                 // Iterate over the items.

--- a/python/src/datasets/trajectory/evidence.rs
+++ b/python/src/datasets/trajectory/evidence.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 use causal_hub::{
     datasets::{CatTrjEv, CatTrjEvT, CatTrjsEv, Dataset},
-    types::{FxIndexMap, FxIndexSet},
+    types::{FxIndexSet, States},
 };
 use numpy::{PyArray1, prelude::*};
 use pyo3::{
@@ -129,7 +129,7 @@ impl PyCatTrjEv {
         );
 
         // Construct the states.
-        let states: FxIndexMap<_, FxIndexSet<_>> = with_states
+        let states: States = with_states
             // If `with_states` is provided, convert it to a FxIndexMap.
             .map(|states| {
                 // Iterate over the items.

--- a/python/src/estimators/structures/mod.rs
+++ b/python/src/estimators/structures/mod.rs
@@ -1,2 +1,5 @@
 mod structural_expectation_maximization;
 pub use structural_expectation_maximization::*;
+
+mod prior_knowledge;
+pub use prior_knowledge::*;

--- a/python/src/estimators/structures/prior_knowledge.rs
+++ b/python/src/estimators/structures/prior_knowledge.rs
@@ -1,0 +1,72 @@
+use causal_hub::{estimators::PK, types::Labels};
+use pyo3::{prelude::*, types::PyIterator};
+use serde::{Deserialize, Serialize};
+
+use crate::impl_deref_from_into;
+
+#[pyclass(name = "PK")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PyPK {
+    inner: PK,
+}
+
+// Implement `Deref`, `From` and `Into` traits.
+impl_deref_from_into!(PyPK, PK);
+
+#[pymethods]
+impl PyPK {
+    #[new]
+    fn new(
+        labels: &Bound<'_, PyIterator>,
+        forbidden: &Bound<'_, PyIterator>,
+        required: &Bound<'_, PyIterator>,
+        temporal_order: &Bound<'_, PyIterator>,
+    ) -> PyResult<Self> {
+        // Convert Python iterators on Python strings to Rust iterators on Rust strings.
+        let labels: Labels = labels
+            .try_iter()?
+            .map(|x| x?.extract::<String>())
+            .collect::<PyResult<_>>()?;
+        // Do the same for the other parameters, but map strings to indices.
+        let forbidden: Vec<(usize, usize)> = forbidden
+            .try_iter()?
+            .map(|x| {
+                // Get the strings and convert them to indices.
+                x?.extract::<(String, String)>().map(|(a, b)| {
+                    (
+                        labels.get_index_of(&a).unwrap(),
+                        labels.get_index_of(&b).unwrap(),
+                    )
+                })
+            })
+            .collect::<PyResult<_>>()?;
+        let required: Vec<(usize, usize)> = required
+            .try_iter()?
+            .map(|x| {
+                // Get the strings and convert them to indices.
+                x?.extract::<(String, String)>().map(|(a, b)| {
+                    (
+                        labels.get_index_of(&a).unwrap(),
+                        labels.get_index_of(&b).unwrap(),
+                    )
+                })
+            })
+            .collect::<PyResult<_>>()?;
+        let temporal_order: Vec<Vec<usize>> = temporal_order
+            .try_iter()?
+            .map(|x| {
+                x?.try_iter()?
+                    .map(|x| {
+                        // Get the string and convert it to an index.
+                        x?.extract::<String>()
+                            .map(|a| labels.get_index_of(&a).unwrap())
+                    })
+                    .collect::<PyResult<Vec<_>>>()
+                    .map_err(PyErr::from)
+            })
+            .collect::<PyResult<_>>()?;
+
+        // Create the prior knowledge structure.
+        Ok(PK::new(labels, forbidden, required, temporal_order).into())
+    }
+}

--- a/python/src/estimators/structures/prior_knowledge.rs
+++ b/python/src/estimators/structures/prior_knowledge.rs
@@ -1,5 +1,5 @@
 use causal_hub::{estimators::PK, types::Labels};
-use pyo3::{prelude::*, types::PyIterator};
+use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::impl_deref_from_into;
@@ -17,10 +17,10 @@ impl_deref_from_into!(PyPK, PK);
 impl PyPK {
     #[new]
     fn new(
-        labels: &Bound<'_, PyIterator>,
-        forbidden: &Bound<'_, PyIterator>,
-        required: &Bound<'_, PyIterator>,
-        temporal_order: &Bound<'_, PyIterator>,
+        labels: &Bound<'_, PyAny>,
+        forbidden: &Bound<'_, PyAny>,
+        required: &Bound<'_, PyAny>,
+        temporal_order: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
         // Convert Python iterators on Python strings to Rust iterators on Rust strings.
         let labels: Labels = labels

--- a/python/src/estimators/structures/structural_expectation_maximization.rs
+++ b/python/src/estimators/structures/structural_expectation_maximization.rs
@@ -63,16 +63,19 @@ pub fn sem(
         "ctpc" => {
             // Set the initial graph to a complete graph.
             let mut initial_graph = DiGraph::complete(evidence.labels());
-            // Set the parents of the initial graph to max_parents.
-            for i in 0..initial_graph.vertices().len() {
-                // Get the parents.
-                let mut pa_i = initial_graph.parents(i);
-                // Choose nodes randomly.
-                pa_i.shuffle(&mut rng);
-                // Remove the excess parents.
-                for j in pa_i.split_off(max_parents) {
-                    // Remove the edge.
-                    initial_graph.del_edge(j, i);
+            // Check if the number of vertices is less than or equal to the maximum number of parents.
+            if initial_graph.vertices().len() > max_parents + 1 {
+                // Set the parents of the initial graph to max_parents.
+                for i in 0..initial_graph.vertices().len() {
+                    // Get the parents.
+                    let mut pa_i = initial_graph.parents(i);
+                    // Choose nodes randomly.
+                    pa_i.shuffle(&mut rng);
+                    // Remove the excess parents.
+                    for j in pa_i.split_off(max_parents) {
+                        // Remove the edge.
+                        initial_graph.del_edge(j, i);
+                    }
                 }
             }
             // Return the initial graph.

--- a/python/src/estimators/structures/structural_expectation_maximization.rs
+++ b/python/src/estimators/structures/structural_expectation_maximization.rs
@@ -222,6 +222,8 @@ pub fn sem(
                     let chi_sq_test = ChiSquaredTest::new(&cache, c_test);
                     // Initialize the CTPC algorithm.
                     let ctpc = CTPC::new(&initial_graph, &f_test, &chi_sq_test);
+                    // Set prior knowledge.
+                    let ctpc = ctpc.with_prior_knowledge(prior_knowledge);
                     // Fit the new structure using CTPC.
                     ctpc.par_fit()
                 }
@@ -230,6 +232,8 @@ pub fn sem(
                     let bic = BIC::new(&cache);
                     // Initialize the CTHC algorithm and set the maximum number of parents.
                     let cthc = CTHC::new(&initial_graph, &bic).with_max_parents(max_parents);
+                    // Set prior knowledge.
+                    let cthc = cthc.with_prior_knowledge(prior_knowledge);
                     // Fit the new structure using CTHC.
                     cthc.par_fit()
                 }

--- a/python/src/estimators/structures/structural_expectation_maximization.rs
+++ b/python/src/estimators/structures/structural_expectation_maximization.rs
@@ -9,6 +9,7 @@ use causal_hub::{
     samplers::{CTBNSampler, ImportanceSampler},
     types::Cache,
 };
+use log::debug;
 use pyo3::{prelude::*, types::PyDict};
 use rand::{RngCore, SeedableRng, seq::SliceRandom};
 use rand_xoshiro::Xoshiro256PlusPlus;
@@ -61,10 +62,14 @@ pub fn sem(
     // Set the initial graph depending on the algorithm.
     let initial_graph = match algorithm {
         "ctpc" => {
+            // Log the graph initialization.
+            debug!("Setting initial graph for CTPC algorithm to a complete graph ...");
             // Set the initial graph to a complete graph.
             let mut initial_graph = DiGraph::complete(evidence.labels());
             // Check if the number of vertices is less than or equal to the maximum number of parents.
             if initial_graph.vertices().len() > max_parents + 1 {
+                // Log the maximum number of parents.
+                debug!("Reducing the number of parents to {max_parents}.");
                 // Set the parents of the initial graph to max_parents.
                 for i in 0..initial_graph.vertices().len() {
                     // Get the parents.
@@ -82,6 +87,8 @@ pub fn sem(
             initial_graph
         }
         "cthc" => {
+            // Log the graph initialization.
+            debug!("Setting initial graph for CTHC algorithm to an empty graph ...");
             // Set the initial graph to an empty graph.
             DiGraph::empty(evidence.labels())
         }
@@ -92,8 +99,12 @@ pub fn sem(
         ),
     };
 
+    // Log the raw estimator initialization.
+    debug!("Initializing the raw estimator for the initial guess ...");
     // Initialize a raw estimator for an initial guess.
     let raw = RE::<'_, _, CatTrjsEv, CatTrjs>::par_new(&mut rng, &evidence);
+    // Log the initial model fitting.
+    debug!("Fitting the initial model using the raw estimator ...");
     // Set the initial model.
     let initial_model = raw.par_fit(initial_graph.clone());
 

--- a/python/src/estimators/structures/structural_expectation_maximization.rs
+++ b/python/src/estimators/structures/structural_expectation_maximization.rs
@@ -56,150 +56,153 @@ pub fn sem(
         .and_then(|x| x.extract(py).ok())
         .unwrap_or_else(|| 0.01);
 
-    // Initialize the random number generator.
-    let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
+    // Release the GIL to allow parallel execution.
+    py.allow_threads(|| {
+        // Initialize the random number generator.
+        let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
 
-    // Set the initial graph depending on the algorithm.
-    let initial_graph = match algorithm {
-        "ctpc" => {
-            // Log the graph initialization.
-            debug!("Setting initial graph for CTPC algorithm to a complete graph ...");
-            // Set the initial graph to a complete graph.
-            let mut initial_graph = DiGraph::complete(evidence.labels());
-            // Check if the number of vertices is less than or equal to the maximum number of parents.
-            if initial_graph.vertices().len() > max_parents + 1 {
-                // Log the maximum number of parents.
-                debug!("Reducing the number of parents to {max_parents}.");
-                // Set the parents of the initial graph to max_parents.
-                for i in 0..initial_graph.vertices().len() {
-                    // Get the parents.
-                    let mut pa_i = initial_graph.parents(i);
-                    // Choose nodes randomly.
-                    pa_i.shuffle(&mut rng);
-                    // Remove the excess parents.
-                    for j in pa_i.split_off(max_parents) {
-                        // Remove the edge.
-                        initial_graph.del_edge(j, i);
+        // Set the initial graph depending on the algorithm.
+        let initial_graph = match algorithm {
+            "ctpc" => {
+                // Log the graph initialization.
+                debug!("Setting initial graph for CTPC algorithm to a complete graph ...");
+                // Set the initial graph to a complete graph.
+                let mut initial_graph = DiGraph::complete(evidence.labels());
+                // Check if the number of vertices is less than or equal to the maximum number of parents.
+                if initial_graph.vertices().len() > max_parents + 1 {
+                    // Log the maximum number of parents.
+                    debug!("Reducing the number of parents to {max_parents}.");
+                    // Set the parents of the initial graph to max_parents.
+                    for i in 0..initial_graph.vertices().len() {
+                        // Get the parents.
+                        let mut pa_i = initial_graph.parents(i);
+                        // Choose nodes randomly.
+                        pa_i.shuffle(&mut rng);
+                        // Remove the excess parents.
+                        for j in pa_i.split_off(max_parents) {
+                            // Remove the edge.
+                            initial_graph.del_edge(j, i);
+                        }
                     }
                 }
-            }
-            // Return the initial graph.
-            initial_graph
-        }
-        "cthc" => {
-            // Log the graph initialization.
-            debug!("Setting initial graph for CTHC algorithm to an empty graph ...");
-            // Set the initial graph to an empty graph.
-            DiGraph::empty(evidence.labels())
-        }
-        _ => panic!(
-            "Failed to get the structure learning algorithm: \n\
-            \t expected:   'ctpc' or 'cthc', \n\
-            \t found:      '{algorithm}'"
-        ),
-    };
-
-    // Log the raw estimator initialization.
-    debug!("Initializing the raw estimator for the initial guess ...");
-    // Initialize a raw estimator for an initial guess.
-    let raw = RAWE::<'_, _, CatTrjsEv, CatTrjs>::par_new(&mut rng, &evidence);
-    // Log the initial model fitting.
-    debug!("Fitting the initial model using the raw estimator ...");
-    // Set the initial model.
-    let initial_model = raw.par_fit(initial_graph.clone());
-
-    // Wrap the random number generator in a RefCell to allow mutable borrowing.
-    let rng = RefCell::new(rng);
-
-    // Define the expectation step.
-    let e_step = |prev_model: &CatCTBN, evidence: &CatTrjsEv| -> CatWtdTrjs {
-        // Reference the random number generator.
-        let mut rng = rng.borrow_mut();
-        // Sample the seeds to parallelize the sampling.
-        let seeds: Vec<_> = (0..evidence.values().len())
-            .map(|_| rng.next_u64())
-            .collect();
-        // Get the max length of the evidence.
-        let max_length = evidence
-            .values()
-            .iter()
-            .map(|e| e.sample_size())
-            .max()
-            .unwrap_or(10);
-        // Fore each (seed, evidence) ...
-        seeds
-            .iter()
-            .zip(evidence)
-            .par_bridge()
-            .map(|(&s, e)| {
-                // Initialize a new random number generator.
-                let mut rng = Xoshiro256PlusPlus::seed_from_u64(s);
-                // Initialize a new sampler.
-                let mut importance = ImportanceSampler::new(&mut rng, prev_model, e);
-                // Perform multiple imputation.
-                let trjs = importance.sample_n_by_length(max_length, 10);
-                // Get the one with the highest weight.
-                trjs.values()
-                    .iter()
-                    .max_by(|a, b| a.weight().partial_cmp(&b.weight()).unwrap())
-                    .unwrap()
-                    .clone()
-            })
-            .collect()
-    };
-
-    // Define the maximization step.
-    let m_step = |_prev_model: &CatCTBN, expectation: &CatWtdTrjs| -> CatCTBN {
-        // Initialize the parameter estimator.
-        let estimator = BE::new(expectation, (1, 1.));
-        // Cache the parameter estimator.
-        let cache = Cache::new(&estimator);
-        // Learn the graph.
-        let fitted_graph = match algorithm {
-            "ctpc" => {
-                // Initialize the F test.
-                let f_test = FTest::new(&cache, f_test);
-                // Initialize the chi-squared test.
-                let chi_sq_test = ChiSquaredTest::new(&cache, c_test);
-                // Initialize the CTPC algorithm.
-                let ctpc = CTPC::new(&initial_graph, &f_test, &chi_sq_test);
-                // Fit the new structure using CTPC.
-                ctpc.par_fit()
+                // Return the initial graph.
+                initial_graph
             }
             "cthc" => {
-                // Initialize the scoring criterion.
-                let bic = BIC::new(&cache);
-                // Initialize the CTHC algorithm and set the maximum number of parents.
-                let cthc = CTHC::new(&initial_graph, &bic).with_max_parents(max_parents);
-                // Fit the new structure using CTHC.
-                cthc.par_fit()
+                // Log the graph initialization.
+                debug!("Setting initial graph for CTHC algorithm to an empty graph ...");
+                // Set the initial graph to an empty graph.
+                DiGraph::empty(evidence.labels())
             }
             _ => panic!(
                 "Failed to get the structure learning algorithm: \n\
-                \t expected:   'ctpc' or 'cthc', \n\
-                \t found:      '{algorithm}'"
+            \t expected:   'ctpc' or 'cthc', \n\
+            \t found:      '{algorithm}'"
             ),
         };
-        // Fit the new model using the expectation.
-        estimator.par_fit(fitted_graph)
-    };
 
-    // Define the stopping criteria.
-    let stop = |prev_model: &CatCTBN, curr_model: &CatCTBN, counter: usize| -> bool {
-        // Check if the models are equal or the counter is greater than the limit.
-        relative_eq!(prev_model, curr_model, epsilon = 5e-2) || counter >= max_iter
-    };
+        // Log the raw estimator initialization.
+        debug!("Initializing the raw estimator for the initial guess ...");
+        // Initialize a raw estimator for an initial guess.
+        let raw = RAWE::<'_, _, CatTrjsEv, CatTrjs>::par_new(&mut rng, &evidence);
+        // Log the initial model fitting.
+        debug!("Fitting the initial model using the raw estimator ...");
+        // Set the initial model.
+        let initial_model = raw.par_fit(initial_graph.clone());
 
-    // Create a new builder.
-    let builder = EMBuilder::new(&initial_model, evidence)
-        .with_e_step(&e_step)
-        .with_m_step(&m_step)
-        .with_stop(&stop)
-        .build();
+        // Wrap the random number generator in a RefCell to allow mutable borrowing.
+        let rng = RefCell::new(rng);
 
-    // Fit the model.
-    let fitted_model = builder.fit();
+        // Define the expectation step.
+        let e_step = |prev_model: &CatCTBN, evidence: &CatTrjsEv| -> CatWtdTrjs {
+            // Reference the random number generator.
+            let mut rng = rng.borrow_mut();
+            // Sample the seeds to parallelize the sampling.
+            let seeds: Vec<_> = (0..evidence.values().len())
+                .map(|_| rng.next_u64())
+                .collect();
+            // Get the max length of the evidence.
+            let max_length = evidence
+                .values()
+                .iter()
+                .map(|e| e.sample_size())
+                .max()
+                .unwrap_or(10);
+            // Fore each (seed, evidence) ...
+            seeds
+                .iter()
+                .zip(evidence)
+                .par_bridge()
+                .map(|(&s, e)| {
+                    // Initialize a new random number generator.
+                    let mut rng = Xoshiro256PlusPlus::seed_from_u64(s);
+                    // Initialize a new sampler.
+                    let mut importance = ImportanceSampler::new(&mut rng, prev_model, e);
+                    // Perform multiple imputation.
+                    let trjs = importance.sample_n_by_length(max_length, 10);
+                    // Get the one with the highest weight.
+                    trjs.values()
+                        .iter()
+                        .max_by(|a, b| a.weight().partial_cmp(&b.weight()).unwrap())
+                        .unwrap()
+                        .clone()
+                })
+                .collect()
+        };
 
-    // Convert the fitted model into a PyDiGraph.
-    Ok(fitted_model.into())
+        // Define the maximization step.
+        let m_step = |_prev_model: &CatCTBN, expectation: &CatWtdTrjs| -> CatCTBN {
+            // Initialize the parameter estimator.
+            let estimator = BE::new(expectation, (1, 1.));
+            // Cache the parameter estimator.
+            let cache = Cache::new(&estimator);
+            // Learn the graph.
+            let fitted_graph = match algorithm {
+                "ctpc" => {
+                    // Initialize the F test.
+                    let f_test = FTest::new(&cache, f_test);
+                    // Initialize the chi-squared test.
+                    let chi_sq_test = ChiSquaredTest::new(&cache, c_test);
+                    // Initialize the CTPC algorithm.
+                    let ctpc = CTPC::new(&initial_graph, &f_test, &chi_sq_test);
+                    // Fit the new structure using CTPC.
+                    ctpc.par_fit()
+                }
+                "cthc" => {
+                    // Initialize the scoring criterion.
+                    let bic = BIC::new(&cache);
+                    // Initialize the CTHC algorithm and set the maximum number of parents.
+                    let cthc = CTHC::new(&initial_graph, &bic).with_max_parents(max_parents);
+                    // Fit the new structure using CTHC.
+                    cthc.par_fit()
+                }
+                _ => panic!(
+                    "Failed to get the structure learning algorithm: \n\
+                \t expected:   'ctpc' or 'cthc', \n\
+                \t found:      '{algorithm}'"
+                ),
+            };
+            // Fit the new model using the expectation.
+            estimator.par_fit(fitted_graph)
+        };
+
+        // Define the stopping criteria.
+        let stop = |prev_model: &CatCTBN, curr_model: &CatCTBN, counter: usize| -> bool {
+            // Check if the models are equal or the counter is greater than the limit.
+            relative_eq!(prev_model, curr_model, epsilon = 5e-2) || counter >= max_iter
+        };
+
+        // Create a new builder.
+        let builder = EMBuilder::new(&initial_model, evidence)
+            .with_e_step(&e_step)
+            .with_m_step(&m_step)
+            .with_stop(&stop)
+            .build();
+
+        // Fit the model.
+        let fitted_model = builder.fit();
+
+        // Convert the fitted model into a PyDiGraph.
+        Ok(fitted_model.into())
+    })
 }

--- a/python/src/estimators/structures/structural_expectation_maximization.rs
+++ b/python/src/estimators/structures/structural_expectation_maximization.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, collections::HashMap, ops::Deref};
 use approx::relative_eq;
 use causal_hub::{
     datasets::{CatTrjs, CatTrjsEv, CatWtdTrjs, Dataset},
-    estimators::{BE, BIC, CTHC, CTPC, ChiSquaredTest, EMBuilder, FTest, ParCTBNEstimator, RE},
+    estimators::{BE, BIC, CTHC, CTPC, ChiSquaredTest, EMBuilder, FTest, ParCTBNEstimator, RAWE},
     graphs::{DiGraph, Graph},
     models::CatCTBN,
     samplers::{CTBNSampler, ImportanceSampler},
@@ -102,7 +102,7 @@ pub fn sem(
     // Log the raw estimator initialization.
     debug!("Initializing the raw estimator for the initial guess ...");
     // Initialize a raw estimator for an initial guess.
-    let raw = RE::<'_, _, CatTrjsEv, CatTrjs>::par_new(&mut rng, &evidence);
+    let raw = RAWE::<'_, _, CatTrjsEv, CatTrjs>::par_new(&mut rng, &evidence);
     // Log the initial model fitting.
     debug!("Fitting the initial model using the raw estimator ...");
     // Set the initial model.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -110,6 +110,7 @@ mod causal_hub {
         #[pymodule_init]
         fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
             // Set the module members.
+            m.add_class::<crate::estimators::PyPK>()?;
             m.add_function(wrap_pyfunction!(crate::estimators::sem, m)?)?;
 
             // Import the submodules.


### PR DESCRIPTION
This pull request introduces several changes aimed at improving code maintainability, readability, and logging functionality. The key updates include replacing repetitive type definitions with aliases for `Labels` and `States`, adding debug logging for dataset creation and loading, and enhancing error messages for better clarity. Below is a categorized summary of the most important changes:

### Code Simplification and Type Alias Adoption
* Replaced `FxIndexSet<String>` and `FxIndexMap<String, FxIndexSet<String>>` with type aliases `Labels` and `States` across multiple dataset-related structs and methods. This change improves readability and consistency (`causal-hub/src/datasets/categorical/dataset.rs`, `causal-hub/src/datasets/categorical/evidence.rs`, `causal-hub/src/datasets/categorical/incomplete.rs`, `causal-hub/src/datasets/categorical/weighted.rs`, `causal-hub/src/datasets/trajectory/dataset.rs`, `causal-hub/src/datasets/trajectory/evidence.rs`, `causal-hub/src/datasets/trajectory/weighted.rs`). [[1]](diffhunk://#diff-c69e0629ef459d6aeec34d23f43d24ff269dcb1ac734947d042e1e0e72be5063L26-R28) [[2]](diffhunk://#diff-568996228d153fb76c6f28d980245f88288291fcc303ec797d4526107d268ef1L92-R93) [[3]](diffhunk://#diff-3d072788e82bc0b28e393099598e4de76acc2a1792235e4d3b1a7f2bd247d81fL18-R19) [[4]](diffhunk://#diff-324253fa2d249e5622d993c101c7a3833e4ea1962cba5597ac044e1269c9f426L21-R22) [[5]](diffhunk://#diff-5ba12ef28502251085df49dc67f98f1bdca9f47827eb390d0de2d7301fb8bb07L190-R190) [[6]](diffhunk://#diff-7b4b2b4c728b1b62ce3b118e25d1d3491143a45847a0a173c2765e5b17266193L128-R129) [[7]](diffhunk://#diff-4ae44910773bba1c317d2a3016193f27f15f25702724c7ad6ea2cc4b1afcd18bL88-R88)

### Logging Enhancements
* Added `log::debug` statements to log important operations, such as loading Bayesian Networks (BNs) and Continuous Time Bayesian Networks (CTBNs), and creating new categorical datasets. This helps in tracing the execution flow and debugging (`causal-hub/src/assets/mod.rs`, `causal-hub/src/datasets/categorical/dataset.rs`). [[1]](diffhunk://#diff-e56c4fb4d383d0d7faacc4c2c97be98fc7e78d4603f2dabd9d4d2affb8a3a1c2R22-R38) [[2]](diffhunk://#diff-c69e0629ef459d6aeec34d23f43d24ff269dcb1ac734947d042e1e0e72be5063L67-R99)

### Improved Error Messages
* Enhanced error messages in dataset validation checks to include more detailed information about the expected and actual values. This change provides clearer feedback when assertions fail (`causal-hub/src/datasets/categorical/dataset.rs`). [[1]](diffhunk://#diff-c69e0629ef459d6aeec34d23f43d24ff269dcb1ac734947d042e1e0e72be5063L67-R99) [[2]](diffhunk://#diff-c69e0629ef459d6aeec34d23f43d24ff269dcb1ac734947d042e1e0e72be5063L96-R124)

### Trait and Method Updates
* Updated the `Dataset` trait to use the `Labels` alias for the `labels` method return type, ensuring consistency across implementations (`causal-hub/src/datasets/mod.rs`, `causal-hub/src/datasets/trajectory/dataset.rs`, `causal-hub/src/datasets/trajectory/evidence.rs`). [[1]](diffhunk://#diff-cd8ab95b541d0b1532eacef0eb3faa258d0fcc3f9cb2eee8772f698ecb543109L20-R20) [[2]](diffhunk://#diff-5ba12ef28502251085df49dc67f98f1bdca9f47827eb390d0de2d7301fb8bb07L320-R322) [[3]](diffhunk://#diff-7b4b2b4c728b1b62ce3b118e25d1d3491143a45847a0a173c2765e5b17266193L702-R704)

### Code Cleanup
* Removed unused type definitions in the `Dataset` trait and replaced them with the newly introduced type aliases, reducing redundancy and improving maintainability (`causal-hub/src/datasets/mod.rs`).

These changes collectively enhance the codebase by improving clarity, reducing redundancy, and adding helpful debugging information.